### PR TITLE
fixes for 5.0.0 compatibility

### DIFF
--- a/euler_2d_shockbubble_amrclaw/Makefile
+++ b/euler_2d_shockbubble_amrclaw/Makefile
@@ -49,10 +49,10 @@ SOURCES = \
   $(CLAW)/riemann/src/rpt2_euler_5wave.f90 \
   $(AMRLIB)/amr2.f90 \
   $(AMRLIB)/bc2amr.f \
-  $(AMRLIB)/b4step2.f \
+  $(AMRLIB)/b4step2.f90 \
   $(AMRLIB)/qad.f \
-  $(AMRLIB)/src2.f \
-  $(AMRLIB)/src1d.f \
+  $(AMRLIB)/src2.f90 \
+  $(AMRLIB)/src1d.f90 \
   $(AMRLIB)/advanc.f \
   $(AMRLIB)/bound.f90 \
   $(AMRLIB)/stepgrid.f \

--- a/euler_2d_shockbubble_amrclaw/qinit.f
+++ b/euler_2d_shockbubble_amrclaw/qinit.f
@@ -3,14 +3,14 @@ c
 c
 c
 c     =====================================================
-       subroutine qinit(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,
+       subroutine qinit(meqn,mbc,mx,my,xlower,ylower,
      &                   dx,dy,q,maux,aux)
 c     =====================================================
 c
 c     # Set initial conditions for q.
 c
        implicit double precision (a-h,o-z)
-       dimension q(meqn,1-mbc:maxmx+mbc, 1-mbc:maxmy+mbc)
+       dimension q(meqn,1-mbc:mx+mbc, 1-mbc:my+mbc)
        common /comic/ qin(5),qout(5)
        common /cominf/ rinf,vinf,einf
 c

--- a/euler_2d_shockbubble_amrclaw/setaux.f
+++ b/euler_2d_shockbubble_amrclaw/setaux.f
@@ -1,5 +1,5 @@
 c     ============================================
-      subroutine setaux(maxmx,maxmy,mbc,mx,my,xlower,ylower,dx,dy,
+      subroutine setaux(mbc,mx,my,xlower,ylower,dx,dy,
      &                  maux,aux)
 c     ============================================
 c
@@ -8,7 +8,7 @@ c     # aux(i,j,1) = y coordinate of cell center for cylindrical source terms
 c
 c     
       implicit double precision (a-h,o-z)
-      dimension aux(maux,1-mbc:maxmx+mbc,1-mbc:maxmy+mbc)
+      dimension aux(maux,1-mbc:mx+mbc,1-mbc:my+mbc)
 c
       do 20 i=1-mbc,mx+mbc
          do 10 j=1-mbc,my+mbc

--- a/euler_2d_shockbubble_amrclaw/src2.f
+++ b/euler_2d_shockbubble_amrclaw/src2.f
@@ -1,12 +1,12 @@
 c
 c
 c =========================================================
-      subroutine src2(maxmx,maxmy,meqn,mbc,mx,my,xlower,ylower,
+      subroutine src2(meqn,mbc,mx,my,xlower,ylower,
      &                 dx,dy,q,maux,aux,t,dt)
 c =========================================================
       implicit double precision(a-h,o-z)
-      dimension    q(meqn,1-mbc:maxmx+mbc, 1-mbc:maxmy+mbc)
-      dimension  aux(maux,1-mbc:maxmx+mbc, 1-mbc:maxmy+mbc)
+      dimension    q(meqn,1-mbc:mx+mbc, 1-mbc:my+mbc)
+      dimension  aux(maux,1-mbc:mx+mbc, 1-mbc:my+mbc)
 c
 c     # source terms for cylindrical symmetry in 2d Euler equations
 c     # about y = 0, so radius = y

--- a/fvmbook/chap10/tvb/Makefile
+++ b/fvmbook/chap10/tvb/Makefile
@@ -40,9 +40,9 @@ SOURCES = \
   limiter.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_advection.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -50,7 +50,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/philim.f \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap11/burgers/Makefile
+++ b/fvmbook/chap11/burgers/Makefile
@@ -36,10 +36,10 @@ MODULES = \
 SOURCES = \
   qinit.f \
   $(CLAW)/riemann/src/rp1_burgers.f90 \
-  $(CLAW)/classic/src/1d/setprob.f \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setprob.f90 \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -47,7 +47,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap11/congestion/Makefile
+++ b/fvmbook/chap11/congestion/Makefile
@@ -37,9 +37,9 @@ SOURCES = \
   qinit.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_traffic.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -47,7 +47,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap11/greenlight/Makefile
+++ b/fvmbook/chap11/greenlight/Makefile
@@ -37,9 +37,9 @@ SOURCES = \
   qinit.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_traffic.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -47,7 +47,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap11/redlight/Makefile
+++ b/fvmbook/chap11/redlight/Makefile
@@ -37,9 +37,9 @@ SOURCES = \
   qinit.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_traffic.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -47,7 +47,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap12/efix/Makefile
+++ b/fvmbook/chap12/efix/Makefile
@@ -36,10 +36,10 @@ MODULES = \
 SOURCES = \
   qinit.f \
   rp1_burgers.f90 \
-  $(CLAW)/classic/src/1d/setprob.f \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setprob.f90 \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -47,7 +47,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap13/collide/Makefile
+++ b/fvmbook/chap13/collide/Makefile
@@ -39,9 +39,9 @@ SOURCES = \
   qinit.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_shallow_roe_with_efix.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -49,7 +49,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap16/vctraffic/Makefile
+++ b/fvmbook/chap16/vctraffic/Makefile
@@ -47,7 +47,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap17/advdiff/Makefile
+++ b/fvmbook/chap17/advdiff/Makefile
@@ -41,9 +41,9 @@ SOURCES = \
   src1.f \
   tridiag.f \
   $(CLAW)/riemann/src/rp1_advection.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \

--- a/fvmbook/chap17/onramp/Makefile
+++ b/fvmbook/chap17/onramp/Makefile
@@ -40,9 +40,9 @@ SOURCES = \
   src1.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_traffic.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \

--- a/fvmbook/chap20/burgers/Makefile
+++ b/fvmbook/chap20/burgers/Makefile
@@ -38,19 +38,19 @@ SOURCES = \
   setprob.f \
   rpn2bu.f \
   rpt2bu.f \
-  $(CLAW)/classic/src/2d/setaux.f \
+  $(CLAW)/classic/src/2d/setaux.f90 \
   $(CLAW)/classic/src/2d/driver.f90 \
   $(CLAW)/classic/src/2d/claw2ez.f \
   $(CLAW)/classic/src/2d/claw2.f \
   $(CLAW)/classic/src/2d/bc2.f \
-  $(CLAW)/classic/src/2d/b4step2.f \
+  $(CLAW)/classic/src/2d/b4step2.f90 \
   $(CLAW)/classic/src/2d/step2.f90 \
   $(CLAW)/classic/src/2d/step2ds.f90 \
   $(CLAW)/classic/src/2d/dimsp2.f \
   $(CLAW)/classic/src/2d/flux2.f90 \
   $(CLAW)/classic/src/2d/copyq2.f \
   $(CLAW)/classic/src/2d/inlinelimiter.f90 \
-  $(CLAW)/classic/src/2d/src2.f \
+  $(CLAW)/classic/src/2d/src2.f90 \
   $(CLAW)/classic/src/2d/out2.f \
   $(CLAW)/classic/src/2d/restart2.f \
   $(CLAW)/classic/src/2d/opendatafile.f

--- a/fvmbook/chap20/rotate/Makefile
+++ b/fvmbook/chap20/rotate/Makefile
@@ -46,14 +46,14 @@ SOURCES = \
   $(CLAW)/classic/src/2d/claw2ez.f \
   $(CLAW)/classic/src/2d/claw2.f \
   $(CLAW)/classic/src/2d/bc2.f \
-  $(CLAW)/classic/src/2d/b4step2.f \
+  $(CLAW)/classic/src/2d/b4step2.f90 \
   $(CLAW)/classic/src/2d/step2.f90 \
   $(CLAW)/classic/src/2d/step2ds.f90 \
   $(CLAW)/classic/src/2d/dimsp2.f \
   $(CLAW)/classic/src/2d/flux2.f90 \
   $(CLAW)/classic/src/2d/copyq2.f \
   $(CLAW)/classic/src/2d/inlinelimiter.f90 \
-  $(CLAW)/classic/src/2d/src2.f \
+  $(CLAW)/classic/src/2d/src2.f90 \
   $(CLAW)/classic/src/2d/out2.f \
   $(CLAW)/classic/src/2d/restart2.f \
   $(CLAW)/classic/src/2d/opendatafile.f

--- a/fvmbook/chap3/acousimple/Makefile
+++ b/fvmbook/chap3/acousimple/Makefile
@@ -39,9 +39,9 @@ SOURCES = \
   qinit.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_acoustics.f90 \
-  $(CLAW)/classic/src/2d/setaux.f \
+  $(CLAW)/classic/src/2d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -49,7 +49,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap6/compareadv/Makefile
+++ b/fvmbook/chap6/compareadv/Makefile
@@ -37,9 +37,9 @@ SOURCES = \
   qinit.f \
   setprob.f \
   $(CLAW)/riemann/src/rp1_advection.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
   $(CLAW)/classic/src/1d/bc1.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -47,7 +47,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap7/acouinflow/Makefile
+++ b/fvmbook/chap7/acouinflow/Makefile
@@ -40,8 +40,8 @@ SOURCES = \
   bc1.f   \
   $(CLAW)/riemann/src/rp1_acoustics.f90 \
   setprob.f \
-  $(CLAW)/classic/src/1d/setaux.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -49,7 +49,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap7/advinflow/Makefile
+++ b/fvmbook/chap7/advinflow/Makefile
@@ -41,8 +41,8 @@ SOURCES = \
   bc1.f \
   g.f\
   $(CLAW)/riemann/src/rp1_advection.f90 \
-  $(CLAW)/classic/src/2d/setaux.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/2d/setaux.f90 \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -50,7 +50,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------

--- a/fvmbook/chap7/standing/Makefile
+++ b/fvmbook/chap7/standing/Makefile
@@ -40,8 +40,8 @@ SOURCES = \
   setprob.f \
   $(CLAW)/classic/src/1d/bc1.f \
   $(CLAW)/riemann/src/rp1_acoustics.f90 \
-  $(CLAW)/classic/src/1d/setaux.f \
-  $(CLAW)/classic/src/1d/b4step1.f \
+  $(CLAW)/classic/src/1d/setaux.f90 \
+  $(CLAW)/classic/src/1d/b4step1.f90 \
   $(CLAW)/classic/src/1d/driver.f90 \
   $(CLAW)/classic/src/1d/claw1ez.f \
   $(CLAW)/classic/src/1d/claw1.f \
@@ -49,7 +49,7 @@ SOURCES = \
   $(CLAW)/classic/src/1d/inlinelimiter.f90 \
   $(CLAW)/classic/src/1d/opendatafile.f \
   $(CLAW)/classic/src/1d/out1.f \
-  $(CLAW)/classic/src/1d/src1.f \
+  $(CLAW)/classic/src/1d/src1.f90 \
   $(CLAW)/classic/src/1d/step1.f90
 
 #-------------------------------------------------------------------


### PR DESCRIPTION
fixed all Makefiles that point to classic and amrclaw default library routines to use new .f90 versions
also fixed calling sequences of routines in euler_2d_shockbubble_amrclaw
