### PR TITLE
added apps/notebooks/nbstripout 

### DIFF
--- a/notebooks/nbstripout
+++ b/notebooks/nbstripout
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""strip outputs from an IPython Notebook
+
+Opens a notebook, strips its output, and writes the outputless version to the original file.
+
+Useful mainly as a git pre-commit hook for users who don't want to track output in VCS.
+
+This does mostly the same thing as the `Clear All Output` command in the notebook UI.
+
+From: https://gist.github.com/minrk/6176788
+
+"""
+
+import io
+import sys
+
+from IPython.nbformat import current
+
+def strip_output(nb):
+    """strip the outputs from a notebook object"""
+    nb.metadata.pop('signature', None)
+    for cell in nb.worksheets[0].cells:
+        if 'outputs' in cell:
+            cell['outputs'] = []
+        if 'prompt_number' in cell:
+            cell['prompt_number'] = None
+    return nb
+
+if __name__ == '__main__':
+    filename = sys.argv[1]
+    with io.open(filename, 'r', encoding='utf8') as f:
+        nb = current.read(f, 'json')
+    nb = strip_output(nb)
+    with io.open(filename, 'w', encoding='utf8') as f:
+        current.write(nb, f, 'json')
+


### PR DESCRIPTION
This file, from https://gist.github.com/minrk/6176788, makes it easy to strip the output from a .ipynb file on disk without changing the live notebook.  This is useful when editing a notebook if you want to do a "git diff" or commit changes without affecting the output displayed in the notebook.  (You can of course clear all output from the notebook menu and save, but then you have to rerun all cells to get back to where you were).  

This also strips out the line

```
    "signature": "sha..."
```

that changes each time the notebook is used even if the input doesn't change.  

To use:

```
    $CLAW/apps/notebooks/nbstripout filename.ipynb
```

It should be possible to use this as a git hook and/or git filter too, according to https://gist.github.com/minrk/6176788, but I haven't yet implemented that.
