### PR TITLE
leafletwidget application for specifying AMR regions in GeoClaw

### DIFF
--- a/notebooks/geoclaw/GeoClawRegionRectangles.ipynb
+++ b/notebooks/geoclaw/GeoClawRegionRectangles.ipynb
@@ -1,172 +1,185 @@
 {
- "metadata": {
-  "name": ""
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# GeoClaw Region definition tool\n",
-      "\n",
-      "The functions below allow the easy selection of rectangles on a map and the generation of the lines that should be added to a GeoClaw `setrun.py` to specify regions where refinement is to be allowed and/or forced at various levels.\n",
-      "\n",
-      "## Set up leaflet widget  and IPython tools\n",
-      "\n",
-      "This notebook requires that leafletwidget is installed and on the PYTHONPATH. This can be cloned from https://github.com/ellisonbg/leafletwidget.  "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import IPython\n",
-      "from leafletwidget import (\n",
-      "    Map,\n",
-      "    Marker,\n",
-      "    TileLayer, ImageOverlay,\n",
-      "    Polyline, Polygon, Rectangle, Circle, CircleMarker,\n",
-      "    GeoJSON,\n",
-      "    DrawControl\n",
-      ")\n",
-      "from leafletwidget import initialize_notebook\n",
-      "from IPython.html import widgets\n",
-      "from IPython.display import display\n",
-      "initialize_notebook()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Define general purpose functions:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "regions = set()\n",
-      "regions = set()\n",
-      "region_color = '#a52a2a'\n",
-      "\n",
-      "def handle_draw(self, action, geo_json):\n",
-      "    global regions\n",
-      "    polygon=[]\n",
-      "    for coords in geo_json['geometry']['coordinates'][0][:-1][:]:\n",
-      "        polygon.append(tuple(coords))\n",
-      "    polygon = tuple(polygon)\n",
-      "    \n",
-      "    if action == 'created':\n",
-      "        regions.add(polygon)\n",
-      "    elif action == 'deleted':\n",
-      "        regions.discard(polygon)\n",
-      "            \n",
-      "def new_map(center=(48,-124.1), zoom=9):\n",
-      "    global regions\n",
-      "    c = widgets.ContainerWidget()\n",
-      "    m = Map(width='1000px',height='600px', center=center, zoom=zoom, \\\n",
-      "            default_tiles=TileLayer(url=u'http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg'))\n",
-      "    c.children = [m]\n",
-      "    regions = set()\n",
-      "    domainDrawControl = DrawControl(\n",
-      "        rectangle={'shapeOptions':{'color':region_color}},\n",
-      "        polygon=None,polyline=None)\n",
-      "\n",
-      "    domainDrawControl.on_draw(handle_draw)\n",
-      "    m.add_control(domainDrawControl)\n",
-      "    display(m)\n",
-      "\n",
-      "def print_regions(regions=regions, minlevel=1, maxlevel=1, t1=0., t2=1e9, digits=6):\n",
-      "    d = digits  # number of digits to print in lat-long\n",
-      "    s = \"regions.append([%%s, %%s, %%g, %%g, %%8.%if, %%8.%if, %%8.%if, %%8.%if])\" % (d,d,d,d)\n",
-      "    for r in regions: \n",
-      "        x1 = r[0][0]\n",
-      "        x2 = r[3][0]\n",
-      "        y1 = r[0][1] \n",
-      "        y2 = r[1][1]\n",
-      "        print s % (minlevel,maxlevel,t1,t2,x1,x2,y1,y2)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "new_map()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "regions1 = regions.copy()  # since regions is global and might be changed below.\n",
-      "print_regions(regions1, minlevel=2, maxlevel=3)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "new_map(center=[48.3553, -124.6421],zoom=12)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": null
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "regions2 = regions.copy()\n",
-      "print_regions(regions2, minlevel=4, maxlevel=6, t1=90., t2=1e9)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "### To update either set of regions, first execute one of these statements:\n",
-      "\n",
-      "Since `regions` is a global variable, make sure it is set properly before trying to add or delete regions to either map above."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# regions = regions1\n",
-      "# regions = regions2"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GeoClaw Region definition tool\n",
+    "\n",
+    "The functions below allow the easy selection of rectangles on a map and the generation of the lines that should be added to a GeoClaw `setrun.py` to specify regions where refinement is to be allowed and/or forced at various levels.\n",
+    "\n",
+    "## Set up leaflet widget  and IPython tools\n",
+    "\n",
+    "This notebook requires that leafletwidget is installed and on the PYTHONPATH. This can be cloned from https://github.com/ellisonbg/leafletwidget.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import IPython\n",
+    "from leafletwidget import (\n",
+    "    Map,\n",
+    "    Marker,\n",
+    "    TileLayer, ImageOverlay,\n",
+    "    Polyline, Polygon, Rectangle, Circle, CircleMarker,\n",
+    "    GeoJSON,\n",
+    "    DrawControl\n",
+    ")\n",
+    "#from leafletwidget import initialize_notebook\n",
+    "from IPython.html import widgets\n",
+    "from IPython.display import display\n",
+    "#initialize_notebook()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define general purpose functions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "regions = set()\n",
+    "regions = set()\n",
+    "region_color = '#a52a2a'\n",
+    "\n",
+    "def handle_draw(self, action, geo_json):\n",
+    "    global regions\n",
+    "    polygon=[]\n",
+    "    for coords in geo_json['geometry']['coordinates'][0][:-1][:]:\n",
+    "        polygon.append(tuple(coords))\n",
+    "    polygon = tuple(polygon)\n",
+    "    \n",
+    "    if action == 'created':\n",
+    "        regions.add(polygon)\n",
+    "    elif action == 'deleted':\n",
+    "        regions.discard(polygon)\n",
+    "            \n",
+    "def new_map(center=(48,-124.1), zoom=9):\n",
+    "    global regions\n",
+    "    c = widgets.Box()\n",
+    "    m = Map(width='1000px',height='600px', center=center, zoom=zoom, \\\n",
+    "            default_tiles=TileLayer(url=u'http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg'))\n",
+    "    c.children = [m]\n",
+    "    regions = set()\n",
+    "    domainDrawControl = DrawControl(\n",
+    "        rectangle={'shapeOptions':{'color':region_color}},\n",
+    "        polygon=None,polyline=None)\n",
+    "\n",
+    "    domainDrawControl.on_draw(handle_draw)\n",
+    "    m.add_control(domainDrawControl)\n",
+    "    display(m)\n",
+    "\n",
+    "def print_regions(regions=regions, minlevel=1, maxlevel=1, t1=0., t2=1e9, digits=6):\n",
+    "    d = digits  # number of digits to print in lat-long\n",
+    "    s = \"regions.append([%%s, %%s, %%g, %%g, %%8.%if, %%8.%if, %%8.%if, %%8.%if])\" % (d,d,d,d)\n",
+    "    for r in regions: \n",
+    "        x1 = r[0][0]\n",
+    "        x2 = r[3][0]\n",
+    "        y1 = r[0][1] \n",
+    "        y2 = r[1][1]\n",
+    "        print s % (minlevel,maxlevel,t1,t2,x1,x2,y1,y2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "new_map()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "regions1 = regions.copy()  # since regions is global and might be changed below.\n",
+    "print_regions(regions1, minlevel=2, maxlevel=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "new_map(center=[48.3553, -124.6421],zoom=12)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "regions2 = regions.copy()\n",
+    "print_regions(regions2, minlevel=4, maxlevel=6, t1=90., t2=1e9)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### To update either set of regions, first execute one of these statements:\n",
+    "\n",
+    "Since `regions` is a global variable, make sure it is set properly before trying to add or delete regions to either map above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# regions = regions1\n",
+    "# regions = regions2"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/notebooks/geoclaw/GeoClawRegionRectangles.ipynb
+++ b/notebooks/geoclaw/GeoClawRegionRectangles.ipynb
@@ -1,0 +1,172 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# GeoClaw Region definition tool\n",
+      "\n",
+      "The functions below allow the easy selection of rectangles on a map and the generation of the lines that should be added to a GeoClaw `setrun.py` to specify regions where refinement is to be allowed and/or forced at various levels.\n",
+      "\n",
+      "## Set up leaflet widget  and IPython tools\n",
+      "\n",
+      "This notebook requires that leafletwidget is installed and on the PYTHONPATH. This can be cloned from https://github.com/ellisonbg/leafletwidget.  "
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "import IPython\n",
+      "from leafletwidget import (\n",
+      "    Map,\n",
+      "    Marker,\n",
+      "    TileLayer, ImageOverlay,\n",
+      "    Polyline, Polygon, Rectangle, Circle, CircleMarker,\n",
+      "    GeoJSON,\n",
+      "    DrawControl\n",
+      ")\n",
+      "from leafletwidget import initialize_notebook\n",
+      "from IPython.html import widgets\n",
+      "from IPython.display import display\n",
+      "initialize_notebook()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Define general purpose functions:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "regions = set()\n",
+      "regions = set()\n",
+      "region_color = '#a52a2a'\n",
+      "\n",
+      "def handle_draw(self, action, geo_json):\n",
+      "    global regions\n",
+      "    polygon=[]\n",
+      "    for coords in geo_json['geometry']['coordinates'][0][:-1][:]:\n",
+      "        polygon.append(tuple(coords))\n",
+      "    polygon = tuple(polygon)\n",
+      "    \n",
+      "    if action == 'created':\n",
+      "        regions.add(polygon)\n",
+      "    elif action == 'deleted':\n",
+      "        regions.discard(polygon)\n",
+      "            \n",
+      "def new_map(center=(48,-124.1), zoom=9):\n",
+      "    global regions\n",
+      "    c = widgets.ContainerWidget()\n",
+      "    m = Map(width='1000px',height='600px', center=center, zoom=zoom, \\\n",
+      "            default_tiles=TileLayer(url=u'http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg'))\n",
+      "    c.children = [m]\n",
+      "    regions = set()\n",
+      "    domainDrawControl = DrawControl(\n",
+      "        rectangle={'shapeOptions':{'color':region_color}},\n",
+      "        polygon=None,polyline=None)\n",
+      "\n",
+      "    domainDrawControl.on_draw(handle_draw)\n",
+      "    m.add_control(domainDrawControl)\n",
+      "    display(m)\n",
+      "\n",
+      "def print_regions(regions=regions, minlevel=1, maxlevel=1, t1=0., t2=1e9, digits=6):\n",
+      "    d = digits  # number of digits to print in lat-long\n",
+      "    s = \"regions.append([%%s, %%s, %%g, %%g, %%8.%if, %%8.%if, %%8.%if, %%8.%if])\" % (d,d,d,d)\n",
+      "    for r in regions: \n",
+      "        x1 = r[0][0]\n",
+      "        x2 = r[3][0]\n",
+      "        y1 = r[0][1] \n",
+      "        y2 = r[1][1]\n",
+      "        print s % (minlevel,maxlevel,t1,t2,x1,x2,y1,y2)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "new_map()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "regions1 = regions.copy()  # since regions is global and might be changed below.\n",
+      "print_regions(regions1, minlevel=2, maxlevel=3)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "new_map(center=[48.3553, -124.6421],zoom=12)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": null
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "regions2 = regions.copy()\n",
+      "print_regions(regions2, minlevel=4, maxlevel=6, t1=90., t2=1e9)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### To update either set of regions, first execute one of these statements:\n",
+      "\n",
+      "Since `regions` is a global variable, make sure it is set properly before trying to add or delete regions to either map above."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "# regions = regions1\n",
+      "# regions = regions2"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
GeoClawRegionRectangles.ipynb  can be used to select rectangles from a map and print out regions in the form needed in `setrun.py`.

Notebook can't really be viewed with nbviewer since the maps won't show up, missing the whole point, so I'm attaching a screen shot.

@cekees: I kludged something up so that it's possible to use a notebook with several maps at different resolutions and go back up and update an earlier one.  The problem is that `regions` is a global variable so it has to be set properly if you want to update an earlier map.  Maybe there's a better way to do this...
![regionrectangles](https://cloud.githubusercontent.com/assets/720122/5329702/50b1939e-7d72-11e4-80aa-6123c400cad4.png)
