### PR TITLE
note that euler/shockbubble/3d not working

### DIFF
--- a/euler/shockbubble/3d/README.rst
+++ b/euler/shockbubble/3d/README.rst
@@ -19,7 +19,8 @@ the bubble.
 Version history:  
 ----------------
 
-- This version works with Clawpack 5.3.0 
+- This version updated for Clawpack 5.3.0 but currently gives an error.
+
 - 28 Dec 2014: 
 
   - Updated `Makefile` to include dimensional splitting 


### PR DESCRIPTION
Oddly the README file said it worked with 5.3.0, so I updated this.

I started adding version info to README's at one point and apparently this did work when we were testing dimensional splitting.

At some point we should add similar info to all README's and update them only when a new release comes out and we've checked they work.