### PR TITLE
update and fix maketopo of the tsunami/chile2010 app

### DIFF
--- a/tsunami/chile2010_fgmax/maketopo.py
+++ b/tsunami/chile2010_fgmax/maketopo.py
@@ -22,15 +22,16 @@ def get_topo(makeplots=False):
     """
     Retrieve the topo file from the GeoClaw repository.
     """
-    from clawpack.geoclaw import topotools, util
+    from clawpack.geoclaw import topotools
+    import clawpack.clawutil.data as data
     topo_fname = 'etopo10min120W60W60S0S.asc'
     url = 'http://www.geoclaw.org/topo/etopo/' + topo_fname
-    util.get_remote_file(url, output_dir=scratch_dir, file_name=topo_fname,
+    data.get_remote_file(url, output_dir=scratch_dir, file_name=topo_fname,
             verbose=True)
 
     if makeplots:
         from matplotlib import pyplot as plt
-        topo = topotools.Topography(topo_fname, topo_type=2)
+        topo = topotools.Topography(os.path.join(scratch_dir,topo_fname), topo_type=2)
         topo.plot()
         fname = os.path.splitext(topo_fname)[0] + '.png'
         plt.savefig(fname)
@@ -98,12 +99,12 @@ def make_dtopo(makeplots=False):
         fault.plot_subfaults(axes=ax1,slip_color=True)
         ax1.set_xlim(x.min(),x.max())
         ax1.set_ylim(y.min(),y.max())
-        dtopo.plot_dz_colors(1.,axes=ax2)
-        fname = os.path.splitext(dtopo_fname)[0] + '.png'
+        dtopo.plot_dZ_colors(1.,axes=ax2)
+        fname = os.path.split(dtopo_fname)[-1] + '.png'
         plt.savefig(fname)
         print "Created ",fname
 
 
 if __name__=='__main__':
-    get_topo(False)
-    make_dtopo(False)
+    get_topo(True)
+    make_dtopo(True)

--- a/tsunami/chile2010_fgmax/maketopo.py
+++ b/tsunami/chile2010_fgmax/maketopo.py
@@ -106,5 +106,5 @@ def make_dtopo(makeplots=False):
 
 
 if __name__=='__main__':
-    get_topo(True)
-    make_dtopo(True)
+    get_topo(False)
+    make_dtopo(False)

--- a/tsunami/chile2010_fgmax/maketopo.py
+++ b/tsunami/chile2010_fgmax/maketopo.py
@@ -100,7 +100,7 @@ def make_dtopo(makeplots=False):
         ax1.set_xlim(x.min(),x.max())
         ax1.set_ylim(y.min(),y.max())
         dtopo.plot_dZ_colors(1.,axes=ax2)
-        fname = os.path.split(dtopo_fname)[-1] + '.png'
+        fname = os.path.splitext(os.path.split(dtopo_fname)[-1])[0] + '.png'
         plt.savefig(fname)
         print "Created ",fname
 


### PR DESCRIPTION
I was trying to reproduce the tsunami/Chile2010_fgmax app, when I found that a few lines of code in the maketopo.py file seemed to be currently incompatible with clawpack-5.3.1. I made some changes and now it works for me, so I wanted to share it with you. Also I made some minor changes to get png files saved in local dir rather than in the scratch_dir, which I think is more useful when using this case as an example.