### PR TITLE
WIP: Riemann tools and new notebooks

### DIFF
--- a/notebooks/riemann/Euler_exact_Riemann_solver.py
+++ b/notebooks/riemann/Euler_exact_Riemann_solver.py
@@ -112,8 +112,14 @@ def exact_riemann_solution(q_l,q_r,gamma=1.4,
         p3 = p_r*(rho3/rho_r)**gamma
         return rho3, u3, p3
     
-    q_l_star = np.squeeze(np.array(primitive_to_conservative(rho_l_star,u,p)))
-    q_r_star = np.squeeze(np.array(primitive_to_conservative(rho_r_star,u,p)))
+    if out_vars == 'conservative':
+        q_l_star = np.squeeze(np.array(primitive_to_conservative(rho_l_star,u,p)))
+        q_r_star = np.squeeze(np.array(primitive_to_conservative(rho_r_star,u,p)))
+    elif out_vars == 'primitive':
+        q_l_star = np.array((rho_l_star,u,p))
+        q_r_star = np.array((rho_r_star,u,p))
+    else:
+        raise ValueError('** Unrecoginzed out_vars = %s' % out_vars)
     
     states = np.column_stack([q_l,q_l_star,q_r_star,q_r])
     speeds = [(ws[0],ws[1]),ws[2],(ws[3],ws[4])]
@@ -121,9 +127,24 @@ def exact_riemann_solution(q_l,q_r,gamma=1.4,
     def reval(xi):
         rar1 = raref1(xi)
         rar3 = raref3(xi)
-        rho_out = (xi<=speeds[0][0])*rho_l + (xi>speeds[0][0])*(xi<=speeds[0][1])*rar1[0] + (xi>speeds[0][1])*(xi<=speeds[1])*rho_l_star + (xi>speeds[1])*(xi<=speeds[2][0])*rho_r_star + (xi>speeds[2][0])*(xi<=speeds[2][1])*rar3[0] + (xi>speeds[2][1])*rho_r
-        u_out   = (xi<=speeds[0][0])*u_l   + (xi>speeds[0][0])*(xi<=speeds[0][1])*rar1[1] + (xi>speeds[0][1])*(xi<=speeds[1])*u          + (xi>speeds[1])*(xi<=speeds[2][0])*u          + (xi>speeds[2][0])*(xi<=speeds[2][1])*rar3[1] + (xi>speeds[2][1])*u_r
-        p_out   = (xi<=speeds[0][0])*p_l   + (xi>speeds[0][0])*(xi<=speeds[0][1])*rar1[2] + (xi>speeds[0][1])*(xi<=speeds[1])*p          + (xi>speeds[1])*(xi<=speeds[2][0])*p          + (xi>speeds[2][0])*(xi<=speeds[2][1])*rar3[2] + (xi>speeds[2][1])*p_r        
+        rho_out = (xi<=speeds[0][0])*rho_l \
+                + (xi>speeds[0][0])*(xi<=speeds[0][1])*rar1[0] \
+                + (xi>speeds[0][1])*(xi<=speeds[1])*rho_l_star \
+                + (xi>speeds[1])*(xi<=speeds[2][0])*rho_r_star \
+                + (xi>speeds[2][0])*(xi<=speeds[2][1])*rar3[0] \
+                + (xi>speeds[2][1])*rho_r
+        u_out   = (xi<=speeds[0][0])*u_l   \
+                + (xi>speeds[0][0])*(xi<=speeds[0][1])*rar1[1] \
+                + (xi>speeds[0][1])*(xi<=speeds[1])*u          \
+                + (xi>speeds[1])*(xi<=speeds[2][0])*u          \
+                + (xi>speeds[2][0])*(xi<=speeds[2][1])*rar3[1] \
+                + (xi>speeds[2][1])*u_r
+        p_out   = (xi<=speeds[0][0])*p_l   \
+                + (xi>speeds[0][0])*(xi<=speeds[0][1])*rar1[2] \
+                + (xi>speeds[0][1])*(xi<=speeds[1])*p          \
+                + (xi>speeds[1])*(xi<=speeds[2][0])*p          \
+                + (xi>speeds[2][0])*(xi<=speeds[2][1])*rar3[2] \
+                + (xi>speeds[2][1])*p_r        
 
         if out_vars == 'conservative':
             q0,q1,q2 =  primitive_to_conservative(rho_out,u_out,p_out)

--- a/notebooks/riemann/Riemann_problem_Euler_exact.ipynb
+++ b/notebooks/riemann/Riemann_problem_Euler_exact.ipynb
@@ -126,9 +126,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since `q[1]` represents fluid velocity in the primitive equations, we can integrate this to also compute the particle paths of gas molecules.  Note that particles are instantaneously accelerated as the show wave passes by for particles starting at locations $x_0 > 0$, whereas particles starting in the region $x_0 < 0$ are smoothly accelerated as the rarefaction passes.  Both sets of particles reach the same velocity in the intermediate state.\n",
+    "### Plot particle trajectories\n",
     "\n",
-    "Also notice that the particles were equally spaced at $t=0$ but at later times thay are closer together to the right of the contact discontinuity than to the left.  Moreover, we see that the denisty increases across the shock wave (compression wave) whereas it decreases across the rarefaction wave (expansion fan)"
+    "Since `q[1]` represents fluid velocity in the primitive equations, we can integrate this to also compute the particle trajectories of gas molecules.  \n",
+    "\n",
+    "We choose the number of particles on each side so that the distance between them is inversely proportional to the density on each side."
    ]
   },
   {
@@ -139,7 +141,22 @@
    },
    "outputs": [],
    "source": [
-    "riemann_tools.plot_riemann_trajectories(states,speeds,riemann_eval,i_vel=1)"
+    "rho_left = q_l[0]\n",
+    "rho_right = q_r[0]\n",
+    "num_right = 10\n",
+    "num_left = 1 + (num_right-1) * rho_left/rho_right\n",
+    "\n",
+    "riemann_tools.plot_riemann_trajectories(states,speeds,riemann_eval,i_vel=1,\n",
+    "                                       num_left=num_left, num_right=num_right)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that particles are instantaneously accelerated as the shock wave passes by for particles starting at locations $x_0 > 0$, whereas particles starting in the region $x_0 < 0$ are smoothly accelerated as the rarefaction passes.  Both sets of particles reach the same velocity $u^*$ in the intermediate state, and travel parallel to the contact discontinuity (which also has propagation speed $s_2 = u^*$).\n",
+    "\n",
+    "Also notice that the the denisty increases across the shock wave (compression wave) whereas it decreases across the rarefaction wave (expansion fan), and that there resulting flow has a discontinuity in density across the contact discontinuity."
    ]
   },
   {

--- a/notebooks/riemann/Riemann_problem_Euler_exact.ipynb
+++ b/notebooks/riemann/Riemann_problem_Euler_exact.ipynb
@@ -4,7 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Euler equations: exact solutions"
+    "# Euler equations: exact solutions\n",
+    "\n",
+    "This notebook illustrates some features of the exact solution to the 1-dimensional Euler equations of compressible gas dynamics.\n",
+    "\n",
+    "The notebook can be found in the clawpack apps respository:  \n",
+    "\n",
+    "- `$CLAW/apps/notebooks/riemann/Riemann_problem_Euler_exact.ipynb`\n",
+    "- See http://www.clawpack.org/apps.html.\n",
+    "\n"
    ]
   },
   {
@@ -36,7 +44,13 @@
    },
    "outputs": [],
    "source": [
-    "from clawpack.riemann import riemann_tools"
+    "#from clawpack.riemann import riemann_tools\n",
+    "\n",
+    "# the version from clawpack.riemann needs updating, \n",
+    "# for active development use the version in this repository instead:\n",
+    "import sys\n",
+    "sys.path.insert(0,'..')  \n",
+    "import riemann_tools"
    ]
   },
   {

--- a/notebooks/riemann/Riemann_problem_Euler_exact.ipynb
+++ b/notebooks/riemann/Riemann_problem_Euler_exact.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Euler equations: exact solutions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "from IPython.display import FileLink\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next cell imports a module containing a function that takes a Riemann problem (left state, right state, and approximate solver), and computes the Riemann solution, as well as functions to plot the solution in various forms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from clawpack.riemann import riemann_tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "We can compute the exact solution to the Riemann problem for the Euler equations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import Euler_exact_Riemann_solver\n",
+    "FileLink('Euler_exact_Riemann_solver.py')  # Link to examine the exact Riemann solver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "gamma = 1.4\n",
+    "\n",
+    "in_vars = 'primitive'  # so components of q are (rho,u,p)\n",
+    "\n",
+    "q_l = np.array((3.,0.,3.))\n",
+    "q_r = np.array((1.,0.,1.))\n",
+    "\n",
+    "states, speeds, riemann_eval = Euler_exact_Riemann_solver.exact_riemann_solution(q_l ,q_r, gamma, \n",
+    "                                                                in_vars=in_vars, out_vars='primitive')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we specified `out_vars = 'primitive'` above, so that the states returned are in terms of the primitive variables (density, velocity, pressure).  This allows us to confirm that the pressure and velocity are constant across the 2-wave (contact discontinuity) and only the density has a jump discontinuity.\n",
+    "\n",
+    "Since the phase space is 3-dimensional, we show two different projections, to density-velocity and to density-pressure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(8,3))\n",
+    "ax = plt.subplot(1,2,1)\n",
+    "riemann_tools.plot_phase(states, ax=ax, i_h = 0, i_v = 1, label_h='density', label_v='velocity')\n",
+    "ax = plt.subplot(1,2,2)\n",
+    "riemann_tools.plot_phase(states, ax=ax, i_h = 0, i_v = 2, label_h='density', label_v='pressure')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In both cases we see that the variable on the vertical axis is constant between the two middle states.\n",
+    "\n",
+    "We can also see this in the solution plotted below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.JSAnimate_plot_riemann(states,speeds,riemann_eval)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since `q[1]` represents fluid velocity in the primitive equations, we can integrate this to also compute the particle paths of gas molecules.  Note that particles are instantaneously accelerated as the show wave passes by for particles starting at locations $x_0 > 0$, whereas particles starting in the region $x_0 < 0$ are smoothly accelerated as the rarefaction passes.  Both sets of particles reach the same velocity in the intermediate state.\n",
+    "\n",
+    "Also notice that the particles were equally spaced at $t=0$ but at later times thay are closer together to the right of the contact discontinuity than to the left.  Moreover, we see that the denisty increases across the shock wave (compression wave) whereas it decreases across the rarefaction wave (expansion fan)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.plot_riemann_trajectories(states,speeds,riemann_eval,i_vel=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot the solution in conservative variables\n",
+    "\n",
+    "If we plot the solution in the conservative variables (density, momentum, energy), we see that all three components have jump discontinuities across the contact discontinuity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "states, speeds, riemann_eval = Euler_exact_Riemann_solver.exact_riemann_solution(q_l ,q_r, gamma, \n",
+    "                                                                in_vars='primitive', out_vars='conservative')\n",
+    "\n",
+    "fig = plt.figure(figsize=(8,3))\n",
+    "ax = plt.subplot(1,2,1)\n",
+    "riemann_tools.plot_phase(states, ax=ax, i_h = 0, i_v = 1, label_h='density', label_v='momentum')\n",
+    "ax = plt.subplot(1,2,2)\n",
+    "riemann_tools.plot_phase(states, ax=ax, i_h = 0, i_v = 2, label_h='density', label_v='energy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.JSAnimate_plot_riemann(states,speeds,riemann_eval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/riemann/Riemann_problem_acoustics.ipynb
+++ b/notebooks/riemann/Riemann_problem_acoustics.ipynb
@@ -4,7 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Riemann problem for acoustics\n"
+    "\n",
+    "# Riemann problem for acoustics\n",
+    "\n",
+    "This notebook illustrates some features of the exact solution to the 1-dimensional constant coefficient acoustics equations.\n",
+    "\n",
+    "The notebook can be found in the clawpack apps respository:  \n",
+    "\n",
+    "- `$CLAW/apps/notebooks/riemann/Riemann_problem_acoustics.ipynb`\n",
+    "- See http://www.clawpack.org/apps.html.\n"
    ]
   },
   {
@@ -35,7 +43,13 @@
    },
    "outputs": [],
    "source": [
-    "from clawpack.riemann import riemann_tools"
+    "#from clawpack.riemann import riemann_tools\n",
+    "\n",
+    "# the version from clawpack.riemann needs updating, \n",
+    "# for active development use the version in this repository instead:\n",
+    "import sys\n",
+    "sys.path.insert(0,'..')  \n",
+    "import riemann_tools"
    ]
   },
   {

--- a/notebooks/riemann/Riemann_problem_acoustics.ipynb
+++ b/notebooks/riemann/Riemann_problem_acoustics.ipynb
@@ -1,0 +1,340 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Riemann problem for acoustics\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The next cell imports a module containing a function that takes a Riemann problem (left state, right state, and approximate solver), and computes the Riemann solution, as well as functions to plot the solution in various forms.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from clawpack.riemann import riemann_tools"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Acoustics: exact solution\n",
+    "We can use this to examine the exact solution of an acoustics Riemann problem.\n",
+    "\n",
+    "This is a linear hyperbolic system of two equations for $q = [p, u]^T$, where $p$ is the pressure perturbation and $u$ is the velocity.  The system is $q_t + Aq_x = 0$, where the coefficient matrix is\n",
+    "\n",
+    "$$\n",
+    "A = \\left[\\begin{array}{cc}0&K\\\\1/\\rho&0\\end{array}\\right], \n",
+    "$$\n",
+    "\n",
+    "where $\\rho$ is the density and $K$ the bulk modulus.  If we define the sound speed $c = \\sqrt{K/\\rho}$ and impedance $Z=\\sqrt{K\\rho}$, then the eigenvalues of the matrix are $s^1 = -c$ and $s^2 = +c$ and the corresponding eigenvectors are\n",
+    "$$\n",
+    "r^1 = \\left[\\begin{array}{c}-Z\\\\1\\end{array}\\right], \\qquad r^2 = \\left[\\begin{array}{c}Z\\\\1\\end{array}\\right].\n",
+    "$$\n",
+    "\n",
+    "For arbitrary states $q_\\ell$ and $q_r$, the Riemann solution consists of two waves propagating with velocities $\\pm c$ with an intermediate state $q_m$ that is connected to $q_\\ell$ by a multiple of $r^1$ and to $q_r$ by a multiple of $r^2$.\n",
+    "\n",
+    "This Riemann solver can be solved by the PyClaw solver `riemann.acoustics_1D_py.acoustics_1D`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from clawpack.riemann.acoustics_1D_py import acoustics_1D\n",
+    "solver = acoustics_1D"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set some problem data needed by the solver:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "problem_data = {}\n",
+    "\n",
+    "rho = 1.            # density\n",
+    "K = 4.              # bulk modulus\n",
+    "c = np.sqrt(K/rho)  # sound speed\n",
+    "Z = np.sqrt(K*rho)  # impedance\n",
+    "\n",
+    "print(\"Density rho = %g, Bulk modulus K = %g\" % (rho,K))\n",
+    "print(\"Sound speed = %g, Impedance = %g\" % (c,Z))\n",
+    "\n",
+    "problem_data['zz'] = Z \n",
+    "problem_data['cc'] = c"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set the left and right states, and solve the Riemann problem"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "q_l = np.array((1,4))  # Left state\n",
+    "q_r = np.array((3,7))  # Right state\n",
+    "\n",
+    "states, s, riemann_eval = riemann_tools.riemann_solution(solver,q_l,q_r,\\\n",
+    "                                            problem_data=problem_data, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot the states in the phase plane:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(4,3))\n",
+    "ax = plt.axes()\n",
+    "riemann_tools.plot_phase(states, ax=ax, label_h='pressure', label_v='velocity')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot the waves in the x-t plane, and the solution at one particular time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = riemann_tools.plot_riemann(states,s,riemann_eval,t=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Animate the Riemann solution:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.JSAnimate_plot_riemann(states,s,riemann_eval)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shock tube problem:\n",
+    "\n",
+    "If the velocity is 0 in both initial states (the shock tube problem) then the resulting Riemann solution consists of pressure jumps of equal magnitude propagating in each direction, with equal and opposite jumps in velocity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "q_l = np.array((5,0))  # Left state\n",
+    "q_r = np.array((1,0))  # Right state\n",
+    "\n",
+    "states, s, riemann_eval = riemann_tools.riemann_solution(solver,q_l,q_r,\\\n",
+    "                                        problem_data=problem_data, verbose=True)\n",
+    "\n",
+    "fig = plt.figure(figsize=(4,3))\n",
+    "ax = plt.axes()\n",
+    "riemann_tools.plot_phase(states, ax=ax, label_h='pressure', label_v='velocity')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.JSAnimate_plot_riemann(states,s,riemann_eval)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot the particle trajectories\n",
+    "\n",
+    "For the acoustics equations, the second component of `q` is the velocity.  By integrating the velocities we can get particle positions.  The following utility function does this for us based on the Riemann solution, solving\n",
+    "\n",
+    "$$\n",
+    "X'(t) = u(X(t), t),\\qquad \\text{for} \\quad t \\geq 0, \\qquad \\text{with initial data} ~ X(0) = x_0\n",
+    "$$\n",
+    "\n",
+    "for a set of 20 initial particle locations $x_0$ evenly distributed along the x-axis at time $=0$.\n",
+    "\n",
+    "Note that the particles initially have velocity 0 and are accelerated to the right by either acoustic wave.  The velocity is constant between the two waves and positive because the pressure chosen was greater to be greater in the left state than in the right state.  If $p_\\ell < p_r$ the the fluid would be accelerated to the left instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.plot_riemann_trajectories(states,s,riemann_eval,i_vel=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Flow into a wall:\n",
+    "\n",
+    "As another example, suppose the pressure is initially the same in the left and right states, while the velocities are non-zero with $u_r = -u_\\ell > 0$.  Particles are converging from both sides and if the initial states have this symmetry, then the result is a middle state $q_m$ in which the velocity is 0 (and the pressure is higher than on either side)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "q_l = np.array((3,2))  # Left state\n",
+    "q_r = np.array((3,-2))  # Right state\n",
+    "\n",
+    "states, s, riemann_eval = riemann_tools.riemann_solution(solver,q_l,q_r,\\\n",
+    "                                        problem_data=problem_data, verbose=True)\n",
+    "\n",
+    "fig = plt.figure(figsize=(4,3))\n",
+    "ax = plt.axes()\n",
+    "riemann_tools.plot_phase(states, ax=ax, label_h='pressure', label_v='velocity')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.JSAnimate_plot_riemann(states,s,riemann_eval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_tools.plot_riemann_trajectories(states,s,riemann_eval,i_vel=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you discard half the solution (for $x>0$ or for $x<0$) then what you see can be viewed as the solution to a problem with fluid streaming at constant velocity toward a solid wall.  The result is an acoustic wave that moves away from the wall, and the fluid behind the shock has been decelerated to velocity 0, i.e. it is stationary at the wall.\n",
+    "\n",
+    "This type of Riemann solution is critical when imposing solid wall boundary conditions in a numerical method. If ghost cells are introduced outside the domain and the state in the ghost cell set by reflecting the interior solution with the symmetry seen here (equal pressure, negated velocity), then the solution to the Riemann problem at the cell interfaces yields a solution that satisfies the desired boundary conditions. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/riemann/riemann_tester.ipynb
+++ b/notebooks/riemann/riemann_tester.ipynb
@@ -18,11 +18,9 @@
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "#from ipywidgets import StaticInteract, RangeWidget\n",
-    "from ipywidgets import interact, interact_manual\n",
-    "import ipywidgets\n",
     "from IPython.display import FileLink\n",
-    "from clawpack import riemann"
+    "from clawpack import riemann\n",
+    "from clawpack.visclaw import animation_tools"
    ]
   },
   {
@@ -75,7 +73,6 @@
    "outputs": [],
    "source": [
     "solver = riemann.acoustics_1D_py.acoustics_1D\n",
-    "num_eqn = riemann.acoustics_1D_py.num_eqn\n",
     "\n",
     "q_l = np.array((1,4))\n",
     "q_r = np.array((3,7))\n",
@@ -85,6 +82,12 @@
     "problem_data['cc'] = 1.0  # sound speed\n",
     "\n",
     "states, s, riemann_eval = riemann_tools.riemann_solution(solver,q_l,q_r,problem_data=problem_data)\n",
+    "\n",
+    "print(\"The states are:\")\n",
+    "print states\n",
+    "print(\"The wave speeds are:\")\n",
+    "print s\n",
+    "\n",
     "riemann_tools.plot_phase(states)"
    ]
   },
@@ -121,9 +124,32 @@
    },
    "outputs": [],
    "source": [
-    "plot_function = riemann_tools.make_plot_function(states,s,riemann_eval)\n",
-    "widget = ipywidgets.IntSlider(min=0,max=len(figs)-1, value=0)\n",
-    "StaticInteract(plot_function, t=RangeWidget(0,.9,.1))"
+    "figs = []\n",
+    "for t in np.linspace(0,1.,11):\n",
+    "    fig = riemann_tools.plot_riemann(states,s,riemann_eval,t)\n",
+    "    figs.append(fig)\n",
+    "    plt.close(fig)\n",
+    "\n",
+    "animation_tools.interact_animate_figs(figs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make JSAnimation movie:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "images = animation_tools.make_images(figs)\n",
+    "animation_tools.JSAnimate_images(images, figsize=(8,4))"
    ]
   },
   {
@@ -162,8 +188,26 @@
     "\n",
     "ex_states, ex_speeds, reval = Euler_exact_Riemann_solver.exact_riemann_solution(q_l ,q_r, gamma)\n",
     "\n",
-    "plot_function = riemann_tools.make_plot_function(ex_states, ex_speeds, reval)\n",
-    "StaticInteract(plot_function, t=RangeWidget(0,.9,.1))"
+    "\n",
+    "figs = []\n",
+    "for t in np.linspace(0,1.,11):\n",
+    "    fig = riemann_tools.plot_riemann(ex_states,ex_speeds,reval,t)\n",
+    "    figs.append(fig)\n",
+    "    plt.close(fig)\n",
+    "    \n",
+    "animation_tools.interact_animate_figs(figs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "images = animation_tools.make_images(figs)\n",
+    "animation_tools.JSAnimate_images(images, figsize=(10,4))"
    ]
   },
   {
@@ -185,7 +229,6 @@
    "outputs": [],
    "source": [
     "solver = riemann.euler_1D_py.euler_roe_1D\n",
-    "num_eqn = riemann.euler_1D_py.num_eqn\n",
     "\n",
     "problem_data = {}\n",
     "problem_data['gamma'] = gamma\n",
@@ -193,7 +236,7 @@
     "problem_data['efix'] = False\n",
     "\n",
     "print \"Roe solver solution to Euler equations:\"\n",
-    "states, s, roe_eval = riemann_tools.riemann_solution(num_eqn,solver,q_l,q_r,problem_data=problem_data)\n",
+    "states, s, roe_eval = riemann_tools.riemann_solution(solver,q_l,q_r,problem_data=problem_data)\n",
     "fig, ax = plt.subplots(1,2,figsize=(10,4))\n",
     "riemann_tools.plot_phase(states,0,1,ax[0])\n",
     "riemann_tools.plot_phase(states,0,2,ax[1])\n",
@@ -208,8 +251,13 @@
    },
    "outputs": [],
    "source": [
-    "plot_function = riemann_tools.make_plot_function(states,s,roe_eval)\n",
-    "StaticInteract(plot_function, t=RangeWidget(0,.9,.1))"
+    "figs = []\n",
+    "for t in np.linspace(0,1.,11):\n",
+    "    fig = riemann_tools.plot_riemann(states,s,roe_eval,t)\n",
+    "    figs.append(fig)\n",
+    "    plt.close(fig)\n",
+    "\n",
+    "animation_tools.interact_animate_figs(figs)"
    ]
   },
   {
@@ -231,7 +279,7 @@
    "source": [
     "solver = riemann.euler_1D_py.euler_hll_1D\n",
     "print \"HLL solver solution to Euler equations:\"\n",
-    "states_hll, s_hll, hll_eval = riemann_tools.riemann_solution(num_eqn,solver,q_l,q_r,problem_data=problem_data)\n",
+    "states_hll, s_hll, hll_eval = riemann_tools.riemann_solution(solver,q_l,q_r,problem_data=problem_data)\n",
     "fig, ax = plt.subplots(1,2,figsize=(10,4))\n",
     "riemann_tools.plot_phase(states_hll,0,1,ax[0])\n",
     "riemann_tools.plot_phase(states_hll,0,2,ax[1])\n",
@@ -246,36 +294,22 @@
    },
    "outputs": [],
    "source": [
-    "plot_function = riemann_tools.make_plot_function(states_hll,s_hll, hll_eval)\n",
-    "StaticInteract(plot_function, t=RangeWidget(0,.9,.1))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Compare the two approximate solvers:\n",
+    "figs = []\n",
+    "for t in np.linspace(0,1.,11):\n",
+    "    fig = riemann_tools.plot_riemann(states_hll,s_hll,hll_eval,t)\n",
+    "    figs.append(fig)\n",
+    "    plt.close(fig)\n",
     "\n",
-    "In the plots below, red is the Roe solution, blue is the HLLE solution."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plot_function = riemann_tools.make_plot_function([states_hll,states],[s_hll,s],[hll_eval,roe_eval])\n",
-    "StaticInteract(plot_function, t=RangeWidget(0,.9,.1))"
+    "animation_tools.interact_animate_figs(figs)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Compare with the exact solution"
+    "## Compare with the exact solution\n",
+    "\n",
+    "In the plots below, red is the true solution, blue is the HLLE solution."
    ]
   },
   {
@@ -286,11 +320,27 @@
    },
    "outputs": [],
    "source": [
-    "plot_function = riemann_tools.make_plot_function([ex_states,states_hll,states],\n",
-    "                                                 [ex_speeds,s_hll,s],\n",
-    "                                                 [reval,hll_eval,roe_eval],\n",
-    "                                                 ['Exact','HLLE','Roe'])\n",
-    "StaticInteract(plot_function, t=RangeWidget(0,.9,.1))"
+    "t = 0.5\n",
+    "fig = riemann_tools.plot_riemann(states_hll,s_hll,hll_eval,t, color='b')\n",
+    "fig = riemann_tools.plot_riemann(ex_states,ex_speeds,reval,t, color='r', fig=fig)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "figs = []\n",
+    "for t in np.linspace(0,1.,11):\n",
+    "    fig = riemann_tools.plot_riemann(states_hll,s_hll,hll_eval,t, color='b')\n",
+    "    fig = riemann_tools.plot_riemann(ex_states,ex_speeds,reval,t, color='r', fig=fig)\n",
+    "    figs.append(fig)\n",
+    "    plt.close(fig)\n",
+    "\n",
+    "animation_tools.interact_animate_figs(figs)"
    ]
   }
  ],


### PR DESCRIPTION
I updated the code from `$CLAW/riemann/src/riemann_tools.py` and moved it to this repo for now, in `notebooks/riemann_tools.py`, since I plan to do more with this in the next couple weeks for the class I'm teaching but don't want to delay release of 5.4.0.

Two new notebooks can be found in the `notebooks/riemann` directory or viewed online, see the links at
  http://depts.washington.edu/clawpack/v5.4.0alpha/notebooks.html#new-examples-under-development-in-apps
