### PR TITLE
WIP: two notebooks in notebooks/pyclaw that give plotly errors

### DIFF
--- a/notebooks/pyclaw/Quadrants.ipynb
+++ b/notebooks/pyclaw/Quadrants.ipynb
@@ -1,238 +1,257 @@
 {
- "metadata": {
-  "name": ""
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Two-dimensional compressible fluid dynamics example: Quadrants\n",
-      "In this example, we solve the Euler equations with initial data consisting of a different state in each quadrant of the unit square.  The following block of code will compute the solution at 40 timeframes and should take 1-2 minutes to run."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from clawpack import pyclaw\n",
-      "from clawpack import riemann\n",
-      "\n",
-      "claw = pyclaw.Controller()\n",
-      "claw.tfinal = 0.6\n",
-      "claw.num_output_times = 40\n",
-      "\n",
-      "riemann_solver = riemann.euler_4wave_2D\n",
-      "claw.solver = pyclaw.ClawSolver2D(riemann_solver)\n",
-      "claw.solver.all_bcs = pyclaw.BC.extrap\n",
-      "\n",
-      "grid_size = (300,300)\n",
-      "domain = pyclaw.Domain( (0.,0.), (1.,1.), grid_size)\n",
-      "\n",
-      "claw.solution = pyclaw.Solution(claw.solver.num_eqn,domain)\n",
-      "gam = 1.4\n",
-      "claw.solution.problem_data['gamma']  = gam\n",
-      "\n",
-      "# Set initial data\n",
-      "q = claw.solution.q\n",
-      "xx,yy = domain.grid.p_centers\n",
-      "l = xx<0.5; r = xx>=0.5; b = yy<0.5; t = yy>=0.5\n",
-      "q[0,...] = 2.*l*t + 1.*l*b + 1.*r*t + 3.*r*b\n",
-      "q[1,...] = 0.75*t - 0.75*b\n",
-      "q[2,...] = 0.5*l  - 0.5*r\n",
-      "q[3,...] = 0.5*q[0,...]*(q[1,...]**2+q[2,...]**2) + 1./(gam-1.)\n",
-      "\n",
-      "claw.keep_copy = True       # Keep solution data in memory for plotting\n",
-      "claw.output_format = None   # Don't write solution data to file\n",
-      "claw.solver.dt_initial=1.e99\n",
-      "status = claw.run()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Plotting: single frame with Matplotlib"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%pylab inline\n",
-      "\n",
-      "frame = claw.frames[40]\n",
-      "density = frame.q[0,:,:]\n",
-      "(vx,vy) = np.gradient(density)\n",
-      "vs = np.sqrt(vx**2 + vy**2)\n",
-      "x, y = frame.state.grid.c_centers    \n",
-      "\n",
-      "plt.pcolormesh(x, y, vs, cmap='RdBu')\n",
-      "plt.axis('image')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Plotting: animation\n",
-      "Next we will plot an animation of all 40 frames, using matplotlib and Jake Vanderplas' JSAnimation code."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from matplotlib import animation\n",
-      "import matplotlib.pyplot as plt\n",
-      "from clawpack.visclaw.JSAnimation import IPython_display\n",
-      "import numpy as np\n",
-      "\n",
-      "fig = plt.figure(figsize=[4,4])\n",
-      "\n",
-      "frame = claw.frames[0]\n",
-      "density = frame.q[0,:,:]\n",
-      "(vx,vy) = np.gradient(density)\n",
-      "vs = np.sqrt(vx**2 + vy**2)\n",
-      "\n",
-      "x, y = frame.state.grid.c_centers    \n",
-      "\n",
-      "# This essentially does a pcolor plot, but it returns the appropriate object\n",
-      "# for use in animation.  See http://matplotlib.org/examples/pylab_examples/pcolor_demo.html.\n",
-      "# Note that it's necessary to transpose the data array because of the way imshow works.\n",
-      "im = plt.imshow(vs.T, cmap='Greys', vmin=vs.min(), vmax=vs.max()/20,\n",
-      "           extent=[x.min(), x.max(), y.min(), y.max()],\n",
-      "           interpolation='nearest', origin='lower')\n",
-      "\n",
-      "def fplot(frame_number):\n",
-      "    frame = claw.frames[frame_number]\n",
-      "    density = frame.q[0,:,:]\n",
-      "    (vx,vy) = np.gradient(density)\n",
-      "    vs = np.sqrt(vx**2 + vy**2)\n",
-      "    im.set_data(vs.T)\n",
-      "    return im,"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "animation.FuncAnimation(fig, fplot, frames=len(claw.frames), interval=20)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Plotting: zoomable, annotated plots with Plotly\n",
-      "Plotly is a new web service that makes it possible (among many other things) to embed interactive plots in an IPython notebook."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import plotly\n",
-      "un='jackp'\n",
-      "k='11m2qbzob9'\n",
-      "py = plotly.plotly(username_or_email=un, key=k)\n",
-      "\n",
-      "frame = claw.frames[40]\n",
-      "density = frame.q[0,:,:]\n",
-      "(vx,vy) = np.gradient(density)\n",
-      "vs = np.sqrt(vx**2 + vy**2)\n",
-      "\n",
-      "# Note that it's necessary to transpose the data array because plotly's heatmap uses imshow.\n",
-      "py.iplot({'z': vs.T, 'type':'heatmap'})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Plotting with VisClaw\n",
-      "To plot with VisClaw, we must first define a setplot function:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def setplot(plotdata):    \n",
-      "    plotfigure = plotdata.new_plotfigure(name='Density', figno=0)\n",
-      "    plotaxes = plotfigure.new_plotaxes()\n",
-      "    plotaxes.title = 'Density'\n",
-      "    plotaxes.scaled = True      # so aspect ratio is 1\n",
-      "    plotitem = plotaxes.new_plotitem(plot_type='2d_schlieren')\n",
-      "    plotitem.plot_var = 0    \n",
-      "    return plotdata"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now we can plot a single frame as follows (most of this code will be unnecessary in the next version):"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from clawpack.visclaw import data\n",
-      "from clawpack.visclaw import frametools\n",
-      "plotdata = data.ClawPlotData()\n",
-      "plotdata.setplot = claw.setplot\n",
-      "claw.plotdata = frametools.call_setplot(claw.setplot,plotdata)\n",
-      "\n",
-      "frame = claw.load_frame(40)\n",
-      "claw.plot_frame(frame)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "VisClaw also has an interactive plotting loop capability.  However, that doesn't work well in the notebook, because no plot appears until you exit the loop, and then you only get the last plot."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "claw.plot()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Two-dimensional compressible fluid dynamics example: Quadrants\n",
+    "In this example, we solve the Euler equations with initial data consisting of a different state in each quadrant of the unit square.  The following block of code will compute the solution at 40 timeframes and should take 1-2 minutes to run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from clawpack import pyclaw\n",
+    "from clawpack import riemann\n",
+    "\n",
+    "claw = pyclaw.Controller()\n",
+    "claw.tfinal = 0.6\n",
+    "claw.num_output_times = 40\n",
+    "\n",
+    "riemann_solver = riemann.euler_4wave_2D\n",
+    "claw.solver = pyclaw.ClawSolver2D(riemann_solver)\n",
+    "claw.solver.all_bcs = pyclaw.BC.extrap\n",
+    "\n",
+    "grid_size = (300,300)\n",
+    "domain = pyclaw.Domain( (0.,0.), (1.,1.), grid_size)\n",
+    "\n",
+    "claw.solution = pyclaw.Solution(claw.solver.num_eqn,domain)\n",
+    "gam = 1.4\n",
+    "claw.solution.problem_data['gamma']  = gam\n",
+    "\n",
+    "# Set initial data\n",
+    "q = claw.solution.q\n",
+    "xx,yy = domain.grid.p_centers\n",
+    "l = xx<0.5; r = xx>=0.5; b = yy<0.5; t = yy>=0.5\n",
+    "q[0,...] = 2.*l*t + 1.*l*b + 1.*r*t + 3.*r*b\n",
+    "q[1,...] = 0.75*t - 0.75*b\n",
+    "q[2,...] = 0.5*l  - 0.5*r\n",
+    "q[3,...] = 0.5*q[0,...]*(q[1,...]**2+q[2,...]**2) + 1./(gam-1.)\n",
+    "\n",
+    "claw.keep_copy = True       # Keep solution data in memory for plotting\n",
+    "claw.output_format = None   # Don't write solution data to file\n",
+    "claw.solver.dt_initial=1.e99\n",
+    "status = claw.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting: single frame with Matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%pylab inline\n",
+    "\n",
+    "frame = claw.frames[40]\n",
+    "density = frame.q[0,:,:]\n",
+    "(vx,vy) = np.gradient(density)\n",
+    "vs = np.sqrt(vx**2 + vy**2)\n",
+    "x, y = frame.state.grid.c_centers    \n",
+    "\n",
+    "plt.pcolormesh(x, y, vs, cmap='RdBu')\n",
+    "plt.axis('image')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting: animation\n",
+    "Next we will plot an animation of all 40 frames, using matplotlib and Jake Vanderplas' JSAnimation code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from matplotlib import animation\n",
+    "import matplotlib.pyplot as plt\n",
+    "from clawpack.visclaw.JSAnimation import IPython_display\n",
+    "import numpy as np\n",
+    "\n",
+    "fig = plt.figure(figsize=[4,4])\n",
+    "\n",
+    "frame = claw.frames[0]\n",
+    "density = frame.q[0,:,:]\n",
+    "(vx,vy) = np.gradient(density)\n",
+    "vs = np.sqrt(vx**2 + vy**2)\n",
+    "\n",
+    "x, y = frame.state.grid.c_centers    \n",
+    "\n",
+    "# This essentially does a pcolor plot, but it returns the appropriate object\n",
+    "# for use in animation.  See http://matplotlib.org/examples/pylab_examples/pcolor_demo.html.\n",
+    "# Note that it's necessary to transpose the data array because of the way imshow works.\n",
+    "im = plt.imshow(vs.T, cmap='Greys', vmin=vs.min(), vmax=vs.max()/20,\n",
+    "           extent=[x.min(), x.max(), y.min(), y.max()],\n",
+    "           interpolation='nearest', origin='lower')\n",
+    "\n",
+    "def fplot(frame_number):\n",
+    "    frame = claw.frames[frame_number]\n",
+    "    density = frame.q[0,:,:]\n",
+    "    (vx,vy) = np.gradient(density)\n",
+    "    vs = np.sqrt(vx**2 + vy**2)\n",
+    "    im.set_data(vs.T)\n",
+    "    return im,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "animation.FuncAnimation(fig, fplot, frames=len(claw.frames), interval=20)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting: zoomable, annotated plots with Plotly\n",
+    "Plotly is a new web service that makes it possible (among many other things) to embed interactive plots in an IPython notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import plotly\n",
+    "un='jackp'\n",
+    "k='11m2qbzob9'\n",
+    "py = plotly.plotly(username_or_email=un, key=k)\n",
+    "\n",
+    "frame = claw.frames[40]\n",
+    "density = frame.q[0,:,:]\n",
+    "(vx,vy) = np.gradient(density)\n",
+    "vs = np.sqrt(vx**2 + vy**2)\n",
+    "\n",
+    "# Note that it's necessary to transpose the data array because plotly's heatmap uses imshow.\n",
+    "py.iplot({'z': vs.T, 'type':'heatmap'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting with VisClaw\n",
+    "To plot with VisClaw, we must first define a setplot function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def setplot(plotdata):    \n",
+    "    plotfigure = plotdata.new_plotfigure(name='Density', figno=0)\n",
+    "    plotaxes = plotfigure.new_plotaxes()\n",
+    "    plotaxes.title = 'Density'\n",
+    "    plotaxes.scaled = True      # so aspect ratio is 1\n",
+    "    plotitem = plotaxes.new_plotitem(plot_type='2d_schlieren')\n",
+    "    plotitem.plot_var = 0    \n",
+    "    return plotdata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can plot a single frame as follows (most of this code will be unnecessary in the next version):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from clawpack.visclaw import data\n",
+    "from clawpack.visclaw import frametools\n",
+    "plotdata = data.ClawPlotData()\n",
+    "plotdata.setplot = claw.setplot\n",
+    "claw.plotdata = frametools.call_setplot(claw.setplot,plotdata)\n",
+    "\n",
+    "frame = claw.load_frame(40)\n",
+    "claw.plot_frame(frame)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "VisClaw also has an interactive plotting loop capability.  However, that doesn't work well in the notebook, because no plot appears until you exit the loop, and then you only get the last plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "claw.plot()"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/notebooks/pyclaw/Stegotons.ipynb
+++ b/notebooks/pyclaw/Stegotons.ipynb
@@ -1,414 +1,441 @@
 {
- "metadata": {
-  "name": ""
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Stegotons: solitary waves arising in non-dispersive periodic media\n",
-      "A fascinating new class of solitary waves was discovered in [a 2003 paper by R.J. LeVeque and D. Yong](http://faculty.washington.edu/rjl/pubs/solitary/40815.pdf).  Solitary waves usually appear as solutions of nonlinear dispersive wave equations, like the KdV or NLS equations.  But the waves discovered by LeVeque and Yong arise in a system of nonlinear wave equations **with no dispersion!**  The nonlinear elasticity equations they investigated are:\n",
-      "\\begin{align}\n",
-      "\\epsilon_t(x,t) - u_x(x,t) & = 0 \\\\\n",
-      "(\\rho(x) u(x,t))_t - \\sigma(\\epsilon(x,t),x)_x & = 0.\n",
-      "\\end{align}\n",
-      "They took the density $\\rho(x)$ and bulk modulus $K(x)$ to be periodic functions and the stress strain relation $\\sigma(\\epsilon,x)$ nonlinear (they used an exponential function, but any nonlinear function will work).\n",
-      "\n",
-      "If $\\rho$ and $K$ are chosen so that the impedance $Z = \\sqrt{\\rho K}$ varies in space, then waves undergo reflection on the fine scale.  Remarkably, the effect of these reflections is an effective behavior that mimics dispersion -- as [predicted already by Santosa & Symes in 1993](http://epubs.siam.org/doi/abs/10.1137/0151049).\n",
-      "\n",
-      "Here we reproduce some of their original experiments in PyClaw.  If you're interested in the simulations, all of the code is provided here and you can run it yourself.  If you're only interested in the results, feel free to just skip over the code."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "from clawpack import riemann\n",
-      "from clawpack import pyclaw\n",
-      "import numpy as np\n",
-      "\n",
-      "riemann_solver = riemann.nonlinear_elasticity_fwave_1D\n",
-      "solver = pyclaw.ClawSolver1D(riemann_solver)\n",
-      "solver.fwave = True\n",
-      "\n",
-      "# Boundary conditions\n",
-      "solver.bc_lower[0] = pyclaw.BC.extrap\n",
-      "solver.bc_upper[0] = pyclaw.BC.extrap\n",
-      "solver.aux_bc_lower[0] = pyclaw.BC.extrap\n",
-      "solver.aux_bc_upper[0] = pyclaw.BC.extrap\n",
-      "\n",
-      "xlower=0.0; xupper=1000.0\n",
-      "cells_per_layer=12; mx=int(round(xupper-xlower))*cells_per_layer\n",
-      "x = pyclaw.Dimension('x',xlower,xupper,mx)\n",
-      "domain = pyclaw.Domain(x)\n",
-      "state = pyclaw.State(domain,solver.num_eqn,3)\n",
-      "xc=state.grid.x.centers\n",
-      "\n",
-      "#Initialize q and aux\n",
-      "KA    = 1.0; rhoA  = 1.0\n",
-      "KB    = 4.0; rhoB  = 4.0\n",
-      "xfrac = xc-np.floor(xc)\n",
-      "\n",
-      "state.aux[0,:] = rhoA*(xfrac<0.5)+rhoB*(xfrac>=0.5) #Density\n",
-      "state.aux[1,:] = KA  *(xfrac<0.5)+KB  *(xfrac>=0.5) #Bulk modulus\n",
-      "state.aux[2,:] = 0. # not used\n",
-      "\n",
-      "sigma = 0.5*np.exp(-((xc-500.)/5.)**2.)\n",
-      "state.q[0,:] = np.log(sigma+1.)/state.aux[1,:]  # Strain\n",
-      "state.q[1,:] = 0.                               # Momentum\n",
-      "\n",
-      "claw = pyclaw.Controller()\n",
-      "claw.solution = pyclaw.Solution(state,domain)\n",
-      "\n",
-      "claw.output_style = 1\n",
-      "claw.num_output_times = 100\n",
-      "claw.tfinal =  550.\n",
-      "claw.solver = solver\n",
-      "claw.keep_copy = True\n",
-      "claw.output_format = None"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Before running the simulation, let's take a quick look at the setup.  The initial condition (stored in `state.q`) is a Gaussian stress perturbation with zero velocity, while the impedance $Z(x)$ is piecewise constant and periodic.  Notice in the plot below that, though the stress is a Gaussian, the strain is discontinuous since the bulk modulus $K(x)$ is discontinuous.\n",
-      "\n",
-      "In each plot, the inset is a closeup of the central region."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import plotly\n",
-      "py = plotly.plotly(username_or_email='DavidKetcheson', key='mgs2lgb203')\n",
-      "\n",
-      "data = [{'x':xc, 'y':state.q[0,:]},{'x':xc[5800:6200],'y':state.q[0,5800:6200],\"xaxis\":\"x2\",\"yaxis\":\"y2\"}]\n",
-      "layout = {\"title\": \"$\\\\text{Strain }(\\epsilon)$\",'showlegend':False,    \"xaxis2\": {\"domain\": [0.6, 0.95],\"anchor\": \"y2\"},\n",
-      "    \"yaxis2\":{\"domain\": [0.2, 0.6],\"anchor\": \"x2\"}}\n",
-      "py.iplot(data,layout=layout)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Z = np.sqrt(state.aux[0,:]*state.aux[1,:])\n",
-      "data = [{'x':xc, 'y':Z},{'x':xc[5800:6200],'y':Z[5800:6200],\"xaxis\":\"x2\",\"yaxis\":\"y2\"}]\n",
-      "layout = {\"title\": \"$\\\\text{Impedance }(Z)$\",'showlegend':False,    \"xaxis2\": {\"domain\": [0.6, 0.95],\"anchor\": \"y2\"},\n",
-      "    \"yaxis2\":{\"domain\": [0.2, 0.6],\"anchor\": \"x2\"}}\n",
-      "py.iplot(data,layout = layout)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "claw.run()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "%pylab inline\n",
-      "from matplotlib import animation\n",
-      "import matplotlib.pyplot as plt\n",
-      "from clawpack.visclaw.JSAnimation import IPython_display\n",
-      "\n",
-      "fig = plt.figure(figsize=[8,4])\n",
-      "ax = plt.axes(xlim=(xc[0], xc[-1]), ylim=(0, 0.4))\n",
-      "line, = ax.plot([], [], lw=1)\n",
-      "\n",
-      "def fplot(i):\n",
-      "    frame = claw.frames[i]\n",
-      "    strain = frame.q[0,:]\n",
-      "    line.set_data(xc, strain)\n",
-      "    ax.set_title('Strain at t='+str(frame.t))\n",
-      "    return line,\n",
-      "\n",
-      "animation.FuncAnimation(fig, fplot, frames=len(claw.frames))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "It's hard to see the details in the animated plot above.  Let's use Plotly to create a plot where we can zoom in:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "data = [{'x':xc, 'y':state.q[0,:]},{'x':xc[11000:11700],'y':state.q[0,11000:11700],\"xaxis\":\"x2\",\"yaxis\":\"y2\"}]\n",
-      "layout = {\"title\": \"Strain ($\\epsilon$)\",'showlegend':False,\"xaxis2\": {\"domain\": [0.4, 0.85],\"anchor\": \"y2\"},\n",
-      "    \"yaxis2\":{\"domain\": [0.15, 0.65],\"anchor\": \"x2\"}}\n",
-      "\n",
-      "py.iplot(data, layout=layout)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "It's easy to see why these waves were dubbed *stegotons*: they're solitary waves that resemble the back of a stegosaurus!"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "## Making the simulation more efficient with a custom boundary condition and a before_step function\n",
-      "\n",
-      "It's clear that the initial pulse is breaking up into a train of waves, but we'd like to study their behavior over longer periods of time, when the solitary waves separate completely.  A nice trick for this purpose is to use a periodic domain and let the waves travel around it several times, thus avoiding the need for a huge computational domain.  This works well as long as the leading waves don't catch up with the tail.  Also, it's enough to examine one of the two wave trains (say, the right-going one).  Indeed, in our periodic domain, the left- and right-going trains would interact, so we'll want to eliminate one of them.\n",
-      "\n",
-      "In order to accomplish this, we'll add two advanced features to our simulation code.  First, we'll implement a custom boundary condition at the left edge, corresponding to an oscillating wall, that will only generate a right-going wave.  Second, we'll add a `before_step()` function.  `before_step` is a hook to do anything special that needs to occur at every (or any) time step in a PyClaw simulation.  We'll write a `before_step` function that changes the boundary conditions to be periodic after the initial wave is generated."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def set_bc_periodic(solver,state):\n",
-      "    \"Change to periodic BCs after initial pulse\"\n",
-      "    if state.t>5*state.problem_data['tw1']:\n",
-      "        solver.bc_lower[0] = pyclaw.BC.periodic\n",
-      "        solver.bc_upper[0] = pyclaw.BC.periodic\n",
-      "        solver.aux_bc_lower[0] = pyclaw.BC.periodic\n",
-      "        solver.aux_bc_upper[0] = pyclaw.BC.periodic\n",
-      "        solver.before_step = None"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def moving_wall_bc(state,dim,t,qbc,num_ghost):\n",
-      "    \"Initial pulse generated at left boundary by prescribed motion\"\n",
-      "    if dim.on_lower_boundary:\n",
-      "        qbc[0,:num_ghost]=qbc[0,num_ghost] \n",
-      "        t=state.t; t1=state.problem_data['t1']; tw1=state.problem_data['tw1']\n",
-      "        amp = state.problem_data['amp'];\n",
-      "        t0 = (t-t1)/tw1\n",
-      "        if abs(t0)<=1.: vwall = -amp*(1.+np.cos(t0*np.pi))\n",
-      "        else: vwall=0.\n",
-      "        for ibc in xrange(num_ghost-1):\n",
-      "            qbc[1,num_ghost-ibc-1] = 2*vwall*state.aux[1,ibc] - qbc[1,num_ghost+ibc]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Now well set up the new simulation."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "riemann_solver = riemann.nonlinear_elasticity_fwave_1D\n",
-      "solver = pyclaw.ClawSolver1D(riemann_solver)\n",
-      "solver.fwave = True\n",
-      "solver.before_step = set_bc_periodic\n",
-      "\n",
-      "# Boundary conditions\n",
-      "solver.bc_lower[0] = pyclaw.BC.custom \n",
-      "solver.user_bc_lower = moving_wall_bc\n",
-      "\n",
-      "solver.bc_upper[0] = pyclaw.BC.extrap\n",
-      "solver.aux_bc_lower[0] = pyclaw.BC.extrap\n",
-      "solver.aux_bc_upper[0] = pyclaw.BC.extrap\n",
-      "\n",
-      "\n",
-      "xlower=0.0; xupper=300.0 \n",
-      "cells_per_layer=24; mx=int(round(xupper-xlower))*cells_per_layer\n",
-      "x = pyclaw.Dimension('x',xlower,xupper,mx)\n",
-      "domain = pyclaw.Domain(x)\n",
-      "state = pyclaw.State(domain,solver.num_eqn,3)\n",
-      "xc=state.grid.x.centers\n",
-      "\n",
-      "#Initialize q and aux\n",
-      "KA    = 1.0; rhoA  = 1.0\n",
-      "KB    = 4.0; rhoB  = 4.0\n",
-      "xfrac = xc-np.floor(xc)\n",
-      "\n",
-      "state.aux[0,:] = rhoA*(xfrac<0.5)+rhoB*(xfrac>=0.5) #Density\n",
-      "state.aux[1,:] = KA  *(xfrac<0.5)+KB  *(xfrac>=0.5) #Bulk modulus\n",
-      "state.aux[2,:] = 0. # not used\n",
-      "\n",
-      "state.q[0,:] = 0.  # Strain \n",
-      "state.q[1,:] = 0.  # Momentum\n",
-      "\n",
-      "state.problem_data = {}\n",
-      "state.problem_data['t1']    = 10.0\n",
-      "state.problem_data['tw1']   = 10.0\n",
-      "state.problem_data['amp']    = 0.1\n",
-      "\n",
-      "claw = pyclaw.Controller()\n",
-      "claw.solution = pyclaw.Solution(state,domain)\n",
-      "claw.solver = solver\n",
-      "\n",
-      "claw.num_output_times = 100\n",
-      "claw.tfinal =  1000.\n",
-      "claw.keep_copy = True\n",
-      "claw.output_format = None"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": true,
-     "input": [
-      "claw.run()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fig = plt.figure(figsize=[8,4])\n",
-      "ax = plt.axes(xlim=(0, 300), ylim=(0, 0.6))\n",
-      "line, = ax.plot([], [])\n",
-      "\n",
-      "animation.FuncAnimation(fig, fplot, frames=len(claw.frames))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "py.iplot(xc,claw.frames[-1].q[0,:])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Experimenting\n",
-      "It's easy to run further experiments on your own, and there are lots of interesting questions to be asked.  For instance, you might wonder what happens if the impedance varies smoothly (say, sinusoidally) instead of being discontinuous.  Here's how you can find out:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import copy\n",
-      "claw.solution = copy.deepcopy(claw.frames[0])  # Reset simulation\n",
-      "\n",
-      "claw.solution.state.aux[0,:] = 0.5*(rhoA+rhoB) + 0.5*(rhoA-rhoB)*np.sin(2*np.pi*xc) #Density\n",
-      "claw.solution.state.aux[1,:] = 0.5*(KA+KB) + 0.5*(KA-KB)*np.sin(2*np.pi*xc) #Bulk modulus\n",
-      "claw.solution.state.aux[2,:] = 0. # not used\n",
-      "\n",
-      "solver = pyclaw.ClawSolver1D(riemann_solver)\n",
-      "solver.fwave = True\n",
-      "\n",
-      "solver.bc_lower[0] = pyclaw.BC.custom\n",
-      "solver.bc_upper[0] = pyclaw.BC.extrap\n",
-      "\n",
-      "solver.aux_bc_lower[0] = pyclaw.BC.extrap\n",
-      "solver.aux_bc_upper[0] = pyclaw.BC.extrap\n",
-      "\n",
-      "solver.user_bc_lower = moving_wall_bc\n",
-      "solver.before_step = set_bc_periodic\n",
-      "claw.solver = solver\n",
-      "claw.tfinal = 1000\n",
-      "claw.frames = []\n",
-      "claw.run()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "fig = plt.figure(figsize=[8,4])\n",
-      "ax = plt.axes(xlim=(0, 300), ylim=(0, 0.6))\n",
-      "line, = ax.plot([], [])\n",
-      "\n",
-      "animation.FuncAnimation(fig, fplot, frames=len(claw.frames))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "py.iplot(xc,claw.frames[-1].q[0,:])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Zoom in on one of the waves above; they have an interesting shape!  Here are some other things to try, off the top of my head:\n",
-      "\n",
-      "- How does the **magnitude of the impedance variation** affect the waves?  What if the impedance is constant?  What if it changes only a little? (see [this paper](http://dx.doi.org/10.4310/CMS.2012.v10.n3.a7) for an explanation)\n",
-      "- What happens if some random perturbations are added to the medium?\n",
-      "- Try isolating two of the solitary waves and then supplying them as an initial condition, and let the taller one overtake the shorter.  What happens when they interact (see the original paper of LeVeque and Yong for some discussion)\n",
-      "\n",
-      "You can also look at multi-dimensional waves like these, but you'll want to run PyClaw in parallel (not in the notebook) to do so.  Take a look at [this paper](http://dx.doi.org/10.1007/s10915-013-9747-3) and some preprints listed [here](http://numerics.kaust.edu.sa/publications.html)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stegotons: solitary waves arising in non-dispersive periodic media\n",
+    "A fascinating new class of solitary waves was discovered in [a 2003 paper by R.J. LeVeque and D. Yong](http://faculty.washington.edu/rjl/pubs/solitary/40815.pdf).  Solitary waves usually appear as solutions of nonlinear dispersive wave equations, like the KdV or NLS equations.  But the waves discovered by LeVeque and Yong arise in a system of nonlinear wave equations **with no dispersion!**  The nonlinear elasticity equations they investigated are:\n",
+    "\\begin{align}\n",
+    "\\epsilon_t(x,t) - u_x(x,t) & = 0 \\\\\n",
+    "(\\rho(x) u(x,t))_t - \\sigma(\\epsilon(x,t),x)_x & = 0.\n",
+    "\\end{align}\n",
+    "They took the density $\\rho(x)$ and bulk modulus $K(x)$ to be periodic functions and the stress strain relation $\\sigma(\\epsilon,x)$ nonlinear (they used an exponential function, but any nonlinear function will work).\n",
+    "\n",
+    "If $\\rho$ and $K$ are chosen so that the impedance $Z = \\sqrt{\\rho K}$ varies in space, then waves undergo reflection on the fine scale.  Remarkably, the effect of these reflections is an effective behavior that mimics dispersion -- as [predicted already by Santosa & Symes in 1993](http://epubs.siam.org/doi/abs/10.1137/0151049).\n",
+    "\n",
+    "Here we reproduce some of their original experiments in PyClaw.  If you're interested in the simulations, all of the code is provided here and you can run it yourself.  If you're only interested in the results, feel free to just skip over the code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from clawpack import riemann\n",
+    "from clawpack import pyclaw\n",
+    "import numpy as np\n",
+    "\n",
+    "riemann_solver = riemann.nonlinear_elasticity_fwave_1D\n",
+    "solver = pyclaw.ClawSolver1D(riemann_solver)\n",
+    "solver.fwave = True\n",
+    "\n",
+    "# Boundary conditions\n",
+    "solver.bc_lower[0] = pyclaw.BC.extrap\n",
+    "solver.bc_upper[0] = pyclaw.BC.extrap\n",
+    "solver.aux_bc_lower[0] = pyclaw.BC.extrap\n",
+    "solver.aux_bc_upper[0] = pyclaw.BC.extrap\n",
+    "\n",
+    "xlower=0.0; xupper=1000.0\n",
+    "cells_per_layer=12; mx=int(round(xupper-xlower))*cells_per_layer\n",
+    "x = pyclaw.Dimension(xlower,xupper,mx,name='x')\n",
+    "domain = pyclaw.Domain(x)\n",
+    "state = pyclaw.State(domain,solver.num_eqn,3)\n",
+    "xc=state.grid.x.centers\n",
+    "\n",
+    "#Initialize q and aux\n",
+    "KA    = 1.0; rhoA  = 1.0\n",
+    "KB    = 4.0; rhoB  = 4.0\n",
+    "xfrac = xc-np.floor(xc)\n",
+    "\n",
+    "state.aux[0,:] = rhoA*(xfrac<0.5)+rhoB*(xfrac>=0.5) #Density\n",
+    "state.aux[1,:] = KA  *(xfrac<0.5)+KB  *(xfrac>=0.5) #Bulk modulus\n",
+    "state.aux[2,:] = 0. # not used\n",
+    "\n",
+    "sigma = 0.5*np.exp(-((xc-500.)/5.)**2.)\n",
+    "state.q[0,:] = np.log(sigma+1.)/state.aux[1,:]  # Strain\n",
+    "state.q[1,:] = 0.                               # Momentum\n",
+    "\n",
+    "claw = pyclaw.Controller()\n",
+    "claw.solution = pyclaw.Solution(state,domain)\n",
+    "\n",
+    "claw.output_style = 1\n",
+    "claw.num_output_times = 100\n",
+    "claw.tfinal =  550.\n",
+    "claw.solver = solver\n",
+    "claw.keep_copy = True\n",
+    "claw.output_format = None"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before running the simulation, let's take a quick look at the setup.  The initial condition (stored in `state.q`) is a Gaussian stress perturbation with zero velocity, while the impedance $Z(x)$ is piecewise constant and periodic.  Notice in the plot below that, though the stress is a Gaussian, the strain is discontinuous since the bulk modulus $K(x)$ is discontinuous.\n",
+    "\n",
+    "In each plot, the inset is a closeup of the central region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import plotly\n",
+    "py = plotly.plotly(username_or_email='DavidKetcheson', key='mgs2lgb203')\n",
+    "\n",
+    "data = [{'x':xc, 'y':state.q[0,:]},{'x':xc[5800:6200],'y':state.q[0,5800:6200],\"xaxis\":\"x2\",\"yaxis\":\"y2\"}]\n",
+    "layout = {\"title\": \"$\\\\text{Strain }(\\epsilon)$\",'showlegend':False,    \"xaxis2\": {\"domain\": [0.6, 0.95],\"anchor\": \"y2\"},\n",
+    "    \"yaxis2\":{\"domain\": [0.2, 0.6],\"anchor\": \"x2\"}}\n",
+    "py.iplot(data,layout=layout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Z = np.sqrt(state.aux[0,:]*state.aux[1,:])\n",
+    "data = [{'x':xc, 'y':Z},{'x':xc[5800:6200],'y':Z[5800:6200],\"xaxis\":\"x2\",\"yaxis\":\"y2\"}]\n",
+    "layout = {\"title\": \"$\\\\text{Impedance }(Z)$\",'showlegend':False,    \"xaxis2\": {\"domain\": [0.6, 0.95],\"anchor\": \"y2\"},\n",
+    "    \"yaxis2\":{\"domain\": [0.2, 0.6],\"anchor\": \"x2\"}}\n",
+    "py.iplot(data,layout = layout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "claw.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%pylab inline\n",
+    "from matplotlib import animation\n",
+    "import matplotlib.pyplot as plt\n",
+    "from clawpack.visclaw.JSAnimation import IPython_display\n",
+    "\n",
+    "fig = plt.figure(figsize=[8,4])\n",
+    "ax = plt.axes(xlim=(xc[0], xc[-1]), ylim=(0, 0.4))\n",
+    "line, = ax.plot([], [], lw=1)\n",
+    "\n",
+    "def fplot(i):\n",
+    "    frame = claw.frames[i]\n",
+    "    strain = frame.q[0,:]\n",
+    "    line.set_data(xc, strain)\n",
+    "    ax.set_title('Strain at t='+str(frame.t))\n",
+    "    return line,\n",
+    "\n",
+    "animation.FuncAnimation(fig, fplot, frames=len(claw.frames))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's hard to see the details in the animated plot above.  Let's use Plotly to create a plot where we can zoom in:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = [{'x':xc, 'y':state.q[0,:]},{'x':xc[11000:11700],'y':state.q[0,11000:11700],\"xaxis\":\"x2\",\"yaxis\":\"y2\"}]\n",
+    "layout = {\"title\": \"Strain ($\\epsilon$)\",'showlegend':False,\"xaxis2\": {\"domain\": [0.4, 0.85],\"anchor\": \"y2\"},\n",
+    "    \"yaxis2\":{\"domain\": [0.15, 0.65],\"anchor\": \"x2\"}}\n",
+    "\n",
+    "py.iplot(data, layout=layout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's easy to see why these waves were dubbed *stegotons*: they're solitary waves that resemble the back of a stegosaurus!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Making the simulation more efficient with a custom boundary condition and a before_step function\n",
+    "\n",
+    "It's clear that the initial pulse is breaking up into a train of waves, but we'd like to study their behavior over longer periods of time, when the solitary waves separate completely.  A nice trick for this purpose is to use a periodic domain and let the waves travel around it several times, thus avoiding the need for a huge computational domain.  This works well as long as the leading waves don't catch up with the tail.  Also, it's enough to examine one of the two wave trains (say, the right-going one).  Indeed, in our periodic domain, the left- and right-going trains would interact, so we'll want to eliminate one of them.\n",
+    "\n",
+    "In order to accomplish this, we'll add two advanced features to our simulation code.  First, we'll implement a custom boundary condition at the left edge, corresponding to an oscillating wall, that will only generate a right-going wave.  Second, we'll add a `before_step()` function.  `before_step` is a hook to do anything special that needs to occur at every (or any) time step in a PyClaw simulation.  We'll write a `before_step` function that changes the boundary conditions to be periodic after the initial wave is generated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def set_bc_periodic(solver,state):\n",
+    "    \"Change to periodic BCs after initial pulse\"\n",
+    "    if state.t>5*state.problem_data['tw1']:\n",
+    "        solver.bc_lower[0] = pyclaw.BC.periodic\n",
+    "        solver.bc_upper[0] = pyclaw.BC.periodic\n",
+    "        solver.aux_bc_lower[0] = pyclaw.BC.periodic\n",
+    "        solver.aux_bc_upper[0] = pyclaw.BC.periodic\n",
+    "        solver.before_step = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def moving_wall_bc(state,dim,t,qbc,num_ghost):\n",
+    "    \"Initial pulse generated at left boundary by prescribed motion\"\n",
+    "    if dim.on_lower_boundary:\n",
+    "        qbc[0,:num_ghost]=qbc[0,num_ghost] \n",
+    "        t=state.t; t1=state.problem_data['t1']; tw1=state.problem_data['tw1']\n",
+    "        amp = state.problem_data['amp'];\n",
+    "        t0 = (t-t1)/tw1\n",
+    "        if abs(t0)<=1.: vwall = -amp*(1.+np.cos(t0*np.pi))\n",
+    "        else: vwall=0.\n",
+    "        for ibc in xrange(num_ghost-1):\n",
+    "            qbc[1,num_ghost-ibc-1] = 2*vwall*state.aux[1,ibc] - qbc[1,num_ghost+ibc]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now well set up the new simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "riemann_solver = riemann.nonlinear_elasticity_fwave_1D\n",
+    "solver = pyclaw.ClawSolver1D(riemann_solver)\n",
+    "solver.fwave = True\n",
+    "solver.before_step = set_bc_periodic\n",
+    "\n",
+    "# Boundary conditions\n",
+    "solver.bc_lower[0] = pyclaw.BC.custom \n",
+    "solver.user_bc_lower = moving_wall_bc\n",
+    "\n",
+    "solver.bc_upper[0] = pyclaw.BC.extrap\n",
+    "solver.aux_bc_lower[0] = pyclaw.BC.extrap\n",
+    "solver.aux_bc_upper[0] = pyclaw.BC.extrap\n",
+    "\n",
+    "\n",
+    "xlower=0.0; xupper=300.0 \n",
+    "cells_per_layer=24; mx=int(round(xupper-xlower))*cells_per_layer\n",
+    "x = pyclaw.Dimension('x',xlower,xupper,mx)\n",
+    "domain = pyclaw.Domain(x)\n",
+    "state = pyclaw.State(domain,solver.num_eqn,3)\n",
+    "xc=state.grid.x.centers\n",
+    "\n",
+    "#Initialize q and aux\n",
+    "KA    = 1.0; rhoA  = 1.0\n",
+    "KB    = 4.0; rhoB  = 4.0\n",
+    "xfrac = xc-np.floor(xc)\n",
+    "\n",
+    "state.aux[0,:] = rhoA*(xfrac<0.5)+rhoB*(xfrac>=0.5) #Density\n",
+    "state.aux[1,:] = KA  *(xfrac<0.5)+KB  *(xfrac>=0.5) #Bulk modulus\n",
+    "state.aux[2,:] = 0. # not used\n",
+    "\n",
+    "state.q[0,:] = 0.  # Strain \n",
+    "state.q[1,:] = 0.  # Momentum\n",
+    "\n",
+    "state.problem_data = {}\n",
+    "state.problem_data['t1']    = 10.0\n",
+    "state.problem_data['tw1']   = 10.0\n",
+    "state.problem_data['amp']    = 0.1\n",
+    "\n",
+    "claw = pyclaw.Controller()\n",
+    "claw.solution = pyclaw.Solution(state,domain)\n",
+    "claw.solver = solver\n",
+    "\n",
+    "claw.num_output_times = 100\n",
+    "claw.tfinal =  1000.\n",
+    "claw.keep_copy = True\n",
+    "claw.output_format = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "claw.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=[8,4])\n",
+    "ax = plt.axes(xlim=(0, 300), ylim=(0, 0.6))\n",
+    "line, = ax.plot([], [])\n",
+    "\n",
+    "animation.FuncAnimation(fig, fplot, frames=len(claw.frames))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "py.iplot(xc,claw.frames[-1].q[0,:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Experimenting\n",
+    "It's easy to run further experiments on your own, and there are lots of interesting questions to be asked.  For instance, you might wonder what happens if the impedance varies smoothly (say, sinusoidally) instead of being discontinuous.  Here's how you can find out:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import copy\n",
+    "claw.solution = copy.deepcopy(claw.frames[0])  # Reset simulation\n",
+    "\n",
+    "claw.solution.state.aux[0,:] = 0.5*(rhoA+rhoB) + 0.5*(rhoA-rhoB)*np.sin(2*np.pi*xc) #Density\n",
+    "claw.solution.state.aux[1,:] = 0.5*(KA+KB) + 0.5*(KA-KB)*np.sin(2*np.pi*xc) #Bulk modulus\n",
+    "claw.solution.state.aux[2,:] = 0. # not used\n",
+    "\n",
+    "solver = pyclaw.ClawSolver1D(riemann_solver)\n",
+    "solver.fwave = True\n",
+    "\n",
+    "solver.bc_lower[0] = pyclaw.BC.custom\n",
+    "solver.bc_upper[0] = pyclaw.BC.extrap\n",
+    "\n",
+    "solver.aux_bc_lower[0] = pyclaw.BC.extrap\n",
+    "solver.aux_bc_upper[0] = pyclaw.BC.extrap\n",
+    "\n",
+    "solver.user_bc_lower = moving_wall_bc\n",
+    "solver.before_step = set_bc_periodic\n",
+    "claw.solver = solver\n",
+    "claw.tfinal = 1000\n",
+    "claw.frames = []\n",
+    "claw.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=[8,4])\n",
+    "ax = plt.axes(xlim=(0, 300), ylim=(0, 0.6))\n",
+    "line, = ax.plot([], [])\n",
+    "\n",
+    "animation.FuncAnimation(fig, fplot, frames=len(claw.frames))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "py.iplot(xc,claw.frames[-1].q[0,:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Zoom in on one of the waves above; they have an interesting shape!  Here are some other things to try, off the top of my head:\n",
+    "\n",
+    "- How does the **magnitude of the impedance variation** affect the waves?  What if the impedance is constant?  What if it changes only a little? (see [this paper](http://dx.doi.org/10.4310/CMS.2012.v10.n3.a7) for an explanation)\n",
+    "- What happens if some random perturbations are added to the medium?\n",
+    "- Try isolating two of the solitary waves and then supplying them as an initial condition, and let the taller one overtake the shorter.  What happens when they interact (see the original paper of LeVeque and Yong for some discussion)\n",
+    "\n",
+    "You can also look at multi-dimensional waves like these, but you'll want to run PyClaw in parallel (not in the notebook) to do so.  Take a look at [this paper](http://dx.doi.org/10.1007/s10915-013-9747-3) and some preprints listed [here](http://numerics.kaust.edu.sa/publications.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
@ketch: I updated these notebooks to Jupyter form but they are giving plotly errors like:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-3026d63be7a5> in <module>()
      1 import plotly
----> 2 py = plotly.plotly(username_or_email='DavidKetcheson', key='mgs2lgb203')
      3 
      4 data = [{'x':xc, 'y':state.q[0,:]},{'x':xc[5800:6200],'y':state.q[0,5800:6200],"xaxis":"x2","yaxis":"y2"}]
      5 layout = {"title": "$\\text{Strain }(\epsilon)$",'showlegend':False,    "xaxis2": {"domain": [0.6, 0.95],"anchor": "y2"},

TypeError: 'module' object is not callable

```
I haven't tried to track down.