### PR TITLE
updated run_with_restart to v5.4.1 and Python3

### DIFF
--- a/checkpt_restart/run_with_restart/README.rst
+++ b/checkpt_restart/run_with_restart/README.rst
@@ -32,11 +32,12 @@ To test 2d version... ::
 Then check the following:
 
 - `run_output.txt`  contains stdout output from each run and info about restarts
-- `_output/fort.gauge`  has final set of gauge data from last execution
-- `_output/fort.gauge_DATETIME`  files contain fort.gauge from earlier
+- `_output/gauge*.txt` should contain the gauge output for the full time
             
-All `fort.gauge*` files need to be catenated together, but there may be some
-overlapping times (after last checkpoint and before code died).
+Note that the `_output/gauge*.txt` might contain some repeated times 
+since the restart will append to the end, starting at the restart time.
+There might also be some missing times from gauge data buffered but not yet
+written to `gauge*.txt` when the run was aborted.
 
 Similary in 3d.
 
@@ -46,3 +47,4 @@ Version history:
 
 - This version works with Clawpack 5.3.1
 
+- This version works with Clawpack 5.4.1 and Python2 or Python3

--- a/checkpt_restart/run_with_restart/run_with_restart.py
+++ b/checkpt_restart/run_with_restart/run_with_restart.py
@@ -44,8 +44,12 @@ Notes:
 
 """
 
+from __future__ import print_function
+from __future__ import absolute_import
+
 import subprocess
 import os, sys
+sys.path.append('.')
 from setrun import setrun
 
 outdir = '_output'
@@ -92,8 +96,8 @@ def examine_outdir(outdir='_output'):
         tb = -Inf
 
     if (ta == -Inf) and (tb == -Inf):
-        print "Could not read fort.tckaaaaa or fort.tckbbbbb in outdir %s" \
-            % outdir
+        print("Could not read fort.tckaaaaa or fort.tckbbbbb in outdir %s" \
+            % outdir)
         latest = None
         t_latest = None
     elif ta > tb:
@@ -121,7 +125,7 @@ def run_code_or_restart():
     finished, latest, t_latest = examine_outdir(outdir)
 
     if finished:
-        print "Code has finished running, remove %s to run again" % outdir
+        print("Code has finished running, remove %s to run again" % outdir)
         return
 
     restart = (latest is not None)
@@ -130,13 +134,13 @@ def run_code_or_restart():
     fname_errors = 'run_errors.txt'
 
     if restart:
-        print "Will attempt to restart using checkpoint file %s at t = %s" \
-                % (latest, t_latest)
-        print "Appending output stream to %s" % fname_output
+        print("Will attempt to restart using checkpoint file %s at t = %s" \
+                % (latest, t_latest))
+        print("Appending output stream to %s" % fname_output)
         access = 'a'
     else:
-        print "Will run code -- no restart"
-        print "Writing output stream to %s" % fname_output
+        print("Will run code -- no restart")
+        print("Writing output stream to %s" % fname_output)
         access = 'w'
 
     fout = open(fname_output, access)
@@ -153,12 +157,13 @@ def run_code_or_restart():
     else:
         make_args = ['make','output']
 
-    if restart:
-        fortgauge = os.path.join(outdir,'fort.gauge')
-        fortgauge2 = os.path.join(outdir,'fort.gauge_%s' % timestamp)
-        os.system("mv %s %s" % (fortgauge,fortgauge2))
-        fout.write("Moving %s to %s \n" % (fortgauge,fortgauge2))
-        fout.flush()
+    #if restart:
+    #    No longer need to do this since new restart now adds to gauge*.txt files
+    #    fortgauge = os.path.join(outdir,'fort.gauge')
+    #    fortgauge2 = os.path.join(outdir,'fort.gauge_%s' % timestamp)
+    #    os.system("mv %s %s" % (fortgauge,fortgauge2))
+    #    fout.write("Moving %s to %s \n" % (fortgauge,fortgauge2))
+    #    fout.flush()
 
     rundata = setrun('amrclaw')
     rundata.clawdata.restart = restart
@@ -171,10 +176,10 @@ def run_code_or_restart():
     return_code = job.wait()
     
     if return_code == 0:
-        print "Successful run\n"
+        print("Successful run\n")
     else:
-        print "Problem running code\n"
-    print "See %s and %s" % (fname_output,fname_errors)
+        print("Problem running code\n")
+    print("See %s and %s" % (fname_output,fname_errors))
     
     fout.close()
     ferr.close()

--- a/checkpt_restart/run_with_restart/test_advection_2d_square/setplot.py
+++ b/checkpt_restart/run_with_restart/test_advection_2d_square/setplot.py
@@ -6,8 +6,10 @@ This module is imported by the plotting routines and then the
 function setplot is called to set the plot parameters.
 """
 
+from __future__ import absolute_import
+
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -19,6 +21,11 @@ def setplot(plotdata):
 
 
     from clawpack.visclaw import colormaps
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
 
     plotdata.clearfigures() # clear any old figures,axes,items data
 
@@ -117,6 +124,7 @@ def setplot(plotdata):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 

--- a/checkpt_restart/run_with_restart/test_burgers_3d_cubedata/setplot.py
+++ b/checkpt_restart/run_with_restart/test_burgers_3d_cubedata/setplot.py
@@ -1,6 +1,6 @@
 
 """ 
-Dummy setplot does nothing currently in 3d.
+setplot currently only plots gauges in 3d.
 Still need to implement Python plotting in 3d.
 
 Set up the plot figures, axes, and items to be done for each frame.
@@ -10,9 +10,11 @@ function setplot is called to set the plot parameters.
     
 """ 
 
+from __future__ import absolute_import
+from __future__ import print_function
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -22,11 +24,34 @@ def setplot(plotdata):
     
     """ 
 
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
     
-    print "**** Python plotting tools not yet implemented in 3d"
-    print "**** No plots will be generated."
+    print("**** Python plotting tools not yet implemented in 3d")
+    print("**** No frame plots will be generated.")
+
+    #-----------------------------------------
+    # Figures for gauges
+    #-----------------------------------------
+    plotfigure = plotdata.new_plotfigure(name='q', figno=300, \
+                    type='each_gauge')
+    plotfigure.clf_each_gauge = True
+
+    # Set up for axes in this figure:
+    plotaxes = plotfigure.new_plotaxes()
+    plotaxes.xlimits = 'auto'
+    plotaxes.ylimits = 'auto'
+    plotaxes.title = 'q'
+
+    # Plot q as blue curve:
+    plotitem = plotaxes.new_plotitem(plot_type='1d_plot')
+    plotitem.plot_var = 0
+    plotitem.plotstyle = 'b-'
+
 
     # Parameters used only when creating html and/or latex hardcopy
     # e.g., via clawpack.visclaw.frametools.printframes:
@@ -42,6 +67,7 @@ def setplot(plotdata):
     plotdata.latex_figsperline = 2           # layout of plots
     plotdata.latex_framesperline = 1         # layout of plots
     plotdata.latex_makepdf = False           # also run pdflatex?
+    plotdata.parallel = True                 # make multiple frame png's at once
 
     return plotdata
 


### PR DESCRIPTION
Note that fort.gauge has been replaced by gauge*.txt, so update instructions too.
Now that we buffer gauge results, some may be lost by Ctrl-C killing of code.

Also `test_burgers_3d_cubedata/setplot.py` modified to at least plot gauges, but this doesn't seem to work. `setplot.py was copied from `clawpack/amrclaw/examples/advection_3d_swirl/setplot.py`, which does seem to work.
