### PR TITLE
Bypassing 'Permission denied' errors'  while fetching submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ or more simply with a new enough version of `git`
 ```
 $> git clone --recursive https://github.com/clawpack/apps
 ```
-Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account. Then, return to the '$CLAW' repository and run
+Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account. Then, return to the `$CLAW` repository and run
 ```
 $> git clone --recursive https://github.com/clawpack/apps
 ```
-Then, enter the 'apps' repository and run
+Then, enter the `apps` repository and run
 ```
 $> git submodule init
 $> git submodule update

--- a/README.md
+++ b/README.md
@@ -12,4 +12,9 @@ or more simply with a new enough version of `git`
 ```
 $> git clone --recursive https://github.com/clawpack/apps
 ```
+Cloning with HTTPS URLS may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account and rerun
+```
+$> git submodule init
+$> git submodule update
+
 Refer to the `git submodule` documentation for instructions on checking out only one submodule.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ or more simply with a new enough version of `git`
 ```
 $> git clone --recursive https://github.com/clawpack/apps
 ```
-Cloning with HTTPS URLS may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account and rerun
+Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account and rerun
 ```
 $> git submodule init
 $> git submodule update

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ or more simply with a new enough version of `git`
 ```
 $> git clone --recursive https://github.com/clawpack/apps
 ```
-Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account and rerun
+Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account. Then, return to the '$CLAW' directory and run
+```
+$> git clone --recursive https://github.com/clawpack/apps
+```
+Then, enter the apps directory and run
 ```
 $> git submodule init
 $> git submodule update

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, 
 ```
 $> git submodule init
 $> git submodule update
-
+```
 Refer to the `git submodule` documentation for instructions on checking out only one submodule.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ or more simply with a new enough version of `git`
 ```
 $> git clone --recursive https://github.com/clawpack/apps
 ```
-Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account. Then, return to the '$CLAW' directory and run
+Cloning with HTTPS URLs may result in 'Permission denied' errors. In that case, add ssh keys to your GitHub account. Then, return to the '$CLAW' repository and run
 ```
 $> git clone --recursive https://github.com/clawpack/apps
 ```
-Then, enter the apps directory and run
+Then, enter the 'apps' repository and run
 ```
 $> git submodule init
 $> git submodule update


### PR DESCRIPTION
The README is modified to suggest adding ssh keys to avoid 'Permission denied' errors encountered when using HTTPS urls.