### PR TITLE
submodules updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/mandli/surge-examples
 [submodule "multilayer-examples"]
 	path = multilayer-examples
-	url = git@github.com:mandli/multilayer-examples
+	url = https://github.com/mandli/multilayer-examples

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a repository of applications of Clawpack and related software.  Many of 
 ### Application Submodules
 Some of the applications are included as git submodules of the main repository.  This allows the responsible developers to maintain their application independent of the rest of the apps repository and lets users checkout only those apps that they are interested in.  If you have already cloned the `apps` repository, then to fetch all submodules you can do the following:
 ```
-$> cd $CLAW/apps
+$> cd $CLAW/apps  # or proper path to apps
 $> git submodule init
 $> git submodule update
 ```
@@ -14,7 +14,7 @@ The file `.gitmodules` contains a list of the submodules that will be fetched.  
 
 If you have not yet cloned the `apps` repository, you can clone it along with all the submodules via the following (with a new enough version of `git`):
 ```
-$> cd  $CLAW  # (or you could put it elsewhere)
+$> cd $CLAW  # or where ever you want apps to be
 $> git clone --recursive https://github.com/clawpack/apps
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 This is a repository of applications of Clawpack and related software.  Many of these examples are maintained as full-fledged examples that would be too large and/or complex to include in the individual repository examples.  Also note that some of the applications are also maintained by people outside of the Clawpack developer team so questions should directed appropriately.
 
 ### Application Submodules
-Some of the applications are included as git submodules of the main repository.  This allows the responsible developers to maintain their application indepdent of the rest of the apps repository and lets users checkout only those apps that they are interested in.  To fetch a submodule inside of the apps repository run
+Some of the applications are included as git submodules of the main repository.  This allows the responsible developers to maintain their application independent of the rest of the apps repository and lets users checkout only those apps that they are interested in.  If you have already cloned the `apps` repository, then to fetch all submodules you can do the following:
 ```
+$> cd $CLAW/apps
 $> git submodule init
 $> git submodule update
 ```
-or more simply with a new enough version of `git`
+
+The file `.gitmodules` contains a list of the submodules that will be fetched.  Refer to the `git submodule` documentation for instructions on checking out only one submodule.
+
+If you have not yet cloned the `apps` repository, you can clone it along with all the submodules via the following (with a new enough version of `git`):
 ```
+$> cd  $CLAW  # (or you could put it elsewhere)
 $> git clone --recursive https://github.com/clawpack/apps
 ```
-Refer to the `git submodule` documentation for instructions on checking out only one submodule.
+


### PR DESCRIPTION
I propose this to replace #85.

I updated .gitmodules and the README.

The README says "Refer to the `git submodule` documentation for instructions on checking out only one submodule." but I couldn't find this in the docs easily.  @mandli, can you provide a pointer or should we drop this sentence?  Removing a set of lines from `.gitmodules` works but gives warnings and an empty directory for the other one.
