### PR TITLE
fix chile2010_fgmax python issues

### DIFF
--- a/tsunami/chile2010_fgmax/README.rst
+++ b/tsunami/chile2010_fgmax/README.rst
@@ -60,4 +60,5 @@ Version history:
 
 - Updated for Clawpack 5.3.0 on 15 Sept 2015
 - Updated for Clawpack 5.7.0 on 18 April 2020
+- Updated for Clawpack 5.7.1 on 4 Sept 2020
 

--- a/tsunami/chile2010_fgmax/plot_fgmax.py
+++ b/tsunami/chile2010_fgmax/plot_fgmax.py
@@ -5,7 +5,8 @@ Plot fgmax output from GeoClaw run.
 
 import matplotlib.pyplot as plt
 import numpy
-from clawpack.geoclaw import fgmax_tools, geoplot
+from clawpack.geoclaw import fgmax_tools
+from clawpack.visclaw import geoplot
 
 def plot_fgmax_grid():
 
@@ -25,7 +26,7 @@ def plot_fgmax_grid():
     # plot arrival time contours and label:
     arrival_t = fg.arrival_time/3600.  # arrival time in hours
     clines_t = numpy.linspace(0,8,17)  # hours
-    clines_t_label = clines_t[::2]  # which ones to label 
+    clines_t_label = clines_t[2::2]  # which ones to label 
     clines_t_colors = ([.5,.5,.5],)
     con_t = plt.contour(fg.X,fg.Y,arrival_t, clines_t,colors=clines_t_colors) 
     plt.clabel(con_t, clines_t_label)


### PR DESCRIPTION
import geoplot from visclaw and make cline labelling start at t=1 hour
to avoid complaint from some version of matplotlib if no t=0 contour