### PR TITLE
Add tidal-examples submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "tsunami-examples"]
 	path = tsunami-examples
 	url = https://github.com/clawpack/tsunami-examples
+[submodule "tidal-examples"]
+	path = tidal-examples
+	url = https://github.com/clawpack/tidal-examples.git


### PR DESCRIPTION
This adds a new submodule for tidal examples in GeoClaw.